### PR TITLE
Adds support for iframe message passing

### DIFF
--- a/src/app/views/query-runner/QueryInput.tsx
+++ b/src/app/views/query-runner/QueryInput.tsx
@@ -10,7 +10,7 @@ export const QueryInputControl = ({
   handleOnUrlChange,
   httpMethods,
   selectedVerb,
-  sampleURL,
+  sampleUrl,
 }: IQueryInputControl) => {
 
   return (
@@ -25,7 +25,7 @@ export const QueryInputControl = ({
         placeholder='Query Sample'
         className='query-text-field'
         onChange={(event, value) => handleOnUrlChange(value)}
-        defaultValue={sampleURL}
+        defaultValue={sampleUrl}
       />
       <PrimaryButton
         onClick={() => handleOnRunQuery()}

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -21,9 +21,42 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
         { key: 'DELETE', text: 'DELETE' },
       ],
       selectedVerb: 'GET',
-      sampleURL: 'https://graph.microsoft.com/v1.0/me/',
+      sampleUrl: 'https://graph.microsoft.com/v1.0/me/',
+      sampleHeaders: {},
+      sampleBody: {},
     };
   }
+
+  public componentDidMount() {
+    window.addEventListener('message', this.receiveMessage, false);
+  }
+
+  public componentWillUnmount() {
+    window.removeEventListener('message', this.receiveMessage);
+  }
+
+  private receiveMessage = (event: MessageEvent) => {
+    const {
+      sampleVerb,
+      sampleHeaders,
+      sampleUrl,
+      sampleBody,
+    } = event.data;
+
+    if (event.origin !== 'http://docs.microsoft.com' || event.source === null) {
+      return;
+    }
+
+    this.setState({
+      sampleUrl,
+      sampleBody,
+      sampleHeaders,
+      selectedVerb: sampleVerb,
+    });
+
+    // @ts-ignore
+    event.source.postMessage('Opened Graph Explorer', event.origin);
+  };
 
   private handleOnMethodChange = (option?: IDropdownOption) => {
     if (option !== undefined) {
@@ -33,16 +66,16 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
 
   private handleOnUrlChange = (newQuery?: string) => {
     if (newQuery) {
-      this.setState({ sampleURL: newQuery });
+      this.setState({ sampleUrl: newQuery });
     }
   };
 
   private handleOnRunQuery = () => {
-    const { sampleURL } = this.state;
+    const { sampleUrl } = this.state;
     const { actions } = this.props;
 
     if (actions) {
-      actions.runQuery(sampleURL);
+      actions.runQuery(sampleUrl);
     }
   };
 
@@ -50,7 +83,7 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
     const {
       httpMethods,
       selectedVerb,
-      sampleURL,
+      sampleUrl,
     } = this.state;
 
     return (
@@ -61,7 +94,7 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
           handleOnUrlChange={this.handleOnUrlChange}
           httpMethods={httpMethods}
           selectedVerb={selectedVerb}
-          sampleURL={sampleURL}
+          sampleUrl={sampleUrl}
         />
         <Request />
       </div>

--- a/src/app/views/query-runner/index.ts
+++ b/src/app/views/query-runner/index.ts
@@ -1,5 +1,7 @@
+import { QueryInputControl } from './QueryInput';
 import QueryRunner from './QueryRunner';
 
 export {
   QueryRunner,
+  QueryInputControl,
 };

--- a/src/tests/views/query-runner.spec.tsx
+++ b/src/tests/views/query-runner.spec.tsx
@@ -1,10 +1,19 @@
-import { shallow } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import React from 'react';
+import configureMockStore from 'redux-mock-store';
 
-import { QueryRunner } from '../../app/views/query-runner';
+import { QueryInputControl } from '../../app/views/query-runner';
+import { QueryRunner } from '../../app/views/query-runner/QueryRunner';
 
 describe('Query Runner Component', () => {
   it('renders without crashing', () => {
     shallow(<QueryRunner/>);
+  });
+
+  it('has default sample url', () => {
+    const wrapper = shallow(<QueryRunner/>);
+    const props = wrapper.children().find(QueryInputControl).props();
+
+    expect(props.sampleUrl).toBe('https://graph.microsoft.com/v1.0/me/');
   });
 });

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -1,7 +1,9 @@
 export interface IQueryRunnerState {
   httpMethods: Array<{ key: string; text: string; }>;
   selectedVerb: string;
-  sampleURL: string;
+  sampleUrl: string;
+  sampleBody: object;
+  sampleHeaders: object;
 }
 
 export interface IQueryRunnerProps {
@@ -16,7 +18,7 @@ export interface IQueryInputControl {
   handleOnUrlChange: Function;
   httpMethods: Array<{ key: string; text: string}>;
   selectedVerb: string;
-  sampleURL: string;
+  sampleUrl: string;
 }
 
 export interface IAction {


### PR DESCRIPTION
## Overview

Adds support to receive message from a host document.

### Demo

N/A

### Notes

`WindowMessenger` uses iframe message passing to send data to an iframe. This PR listens for a message event and extracts the data.
The data should be an object with the following type 
```
{
    sampleUrl: string;
    sampleVerb: string;
    sampleBody: object;
    sampleHeaders: object;
{
```
## Testing Instructions

Embed GE in an iframe and send a message to the iframe.