### PR TITLE
fix infinite loading when popup window is closed

### DIFF
--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -41,10 +41,10 @@ export class Authentication extends Component<IAuthenticationProps,  IAuthentica
         accessToken = await getAccessToken();
       } catch (e) {
         this.setState({
-          loading: false
+          loading: false,
         });
       }
-      
+
       if (accessToken) {
         authenticatedUser.token = accessToken;
         authenticatedUser.status = true;

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -35,7 +35,16 @@ export class Authentication extends Component<IAuthenticationProps,  IAuthentica
     if (authenticatedUser.status) {
       this.signOut();
     } else {
-      const accessToken = await getAccessToken();
+      let accessToken;
+
+      try {
+        accessToken = await getAccessToken();
+      } catch (e) {
+        this.setState({
+          loading: false
+        });
+      }
+      
       if (accessToken) {
         authenticatedUser.token = accessToken;
         authenticatedUser.status = true;


### PR DESCRIPTION
## Overview

When the sign in with Microsoft button is clicked and a user closes the signup/sign in popup window the button deosn't go back to the initial state.
### Demo
<img width="216" alt="Screen Shot 2019-04-15 at 01 02 58" src="https://user-images.githubusercontent.com/22243090/56100069-7863af80-5f1d-11e9-97eb-6db1c3e657d3.png">
You get this error in the console.
<img width="1680" alt="Screen Shot 2019-04-15 at 01 02 35" src="https://user-images.githubusercontent.com/22243090/56100075-84e80800-5f1d-11e9-8732-63654021aea7.png">

