### PR TITLE
bug: authenticated state lost on page reload

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3160,11 +3160,13 @@
             },
             "balanced-match": {
               "version": "1.0.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "brace-expansion": {
               "version": "1.1.11",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "balanced-match": "^1.0.0",
                 "concat-map": "0.0.1"
@@ -3177,15 +3179,18 @@
             },
             "code-point-at": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "concat-map": {
               "version": "0.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "console-control-strings": {
               "version": "1.1.0",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "core-util-is": {
               "version": "1.0.2",
@@ -3288,7 +3293,8 @@
             },
             "inherits": {
               "version": "2.0.3",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "ini": {
               "version": "1.3.5",
@@ -3298,6 +3304,7 @@
             "is-fullwidth-code-point": {
               "version": "1.0.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "number-is-nan": "^1.0.0"
               }
@@ -3310,17 +3317,20 @@
             "minimatch": {
               "version": "3.0.4",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "brace-expansion": "^1.1.7"
               }
             },
             "minimist": {
               "version": "0.0.8",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "minipass": {
               "version": "2.3.5",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "safe-buffer": "^5.1.2",
                 "yallist": "^3.0.0"
@@ -3337,6 +3347,7 @@
             "mkdirp": {
               "version": "0.5.1",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "minimist": "0.0.8"
               }
@@ -3409,7 +3420,8 @@
             },
             "number-is-nan": {
               "version": "1.0.1",
-              "bundled": true
+              "bundled": true,
+              "optional": true
             },
             "object-assign": {
               "version": "4.1.1",
@@ -3419,6 +3431,7 @@
             "once": {
               "version": "1.4.0",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "wrappy": "1"
               }
@@ -3524,6 +3537,7 @@
             "string-width": {
               "version": "1.0.2",
               "bundled": true,
+              "optional": true,
               "requires": {
                 "code-point-at": "^1.0.0",
                 "is-fullwidth-code-point": "^1.0.0",

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -106,7 +106,8 @@ export class Authentication extends Component<IAuthenticationProps,  IAuthentica
   };
 
   public render() {
-    const { authenticatedUser, loading } = this.state;
+    const { loading } = this.state;
+    const { authenticatedUser } = this.props.authenticatedUser;
     const buttonLabel = authenticatedUser.status ? 'sign out' : 'sign in';
 
     return (
@@ -125,9 +126,9 @@ function mapDispatchToProps(dispatch: Dispatch): object {
   };
 }
 
-function mapStateToProps(state: IAuthenticationState) {
+function mapStateToProps(state: any) {
   return {
-    authenticatedUser: state.authenticatedUser,
+    authenticatedUser: state.authResponse.authenticatedUser,
   };
 }
 

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -85,6 +85,18 @@ export class Authentication extends Component<IAuthenticationProps,  IAuthentica
     }
   };
 
+  public componentDidMount = () => {
+    const authenticatedUser = localStorage.getItem('authenticatedUser');
+    const authUser = (authenticatedUser) ? JSON.parse(authenticatedUser) : null;
+
+    if (authenticatedUser && this.props.actions && authUser.status) {
+      this.props.actions.authenticateUser(authUser);
+      this.setState({
+        authenticatedUser: authUser,
+      });
+    }
+  }
+
   public signOut = (): void => {
     const { actions } = this.props;
     if (actions) {
@@ -106,10 +118,8 @@ export class Authentication extends Component<IAuthenticationProps,  IAuthentica
   };
 
   public render() {
-    const { loading } = this.state;
-    const { authenticatedUser } = this.props.authenticatedUser;
-    const buttonLabel = authenticatedUser.status ? 'sign out' : 'sign in';
-
+    const { authenticatedUser, loading } = this.state;
+    const buttonLabel = (authenticatedUser && authenticatedUser.status) ? 'sign out' : 'sign in';
     return (
       <div className='authentication-container'>
         <SubmitButton className='signIn-button' text={buttonLabel} handleOnClick={this.signIn} submitting={loading} />

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -19,11 +19,8 @@ import { store } from './store';
 import './styles/index.scss';
 
 initializeIcons();
-const authUser = localStorage.getItem('authenticatedUser');
-const authenticatedUser = (authUser) ? JSON.parse(authUser) : null;
-let authResponse = {};
-authResponse = {...authResponse, authenticatedUser };
-const appState = store({ authResponse });
+
+const appState = store({});
 
 const supportedLocales = ['de-DE', 'en-US', 'es-ES', 'fr-FR', 'ja-JP', 'pt-BR', 'ru-RU', 'zh-CN'];
 

--- a/src/types/authentication.ts
+++ b/src/types/authentication.ts
@@ -5,6 +5,7 @@ export interface IAuthenticationProps {
     queryActions?: {
       runQuery: Function;
     };
+    authenticatedUser: IAuthenticationState;
   }
 
 export interface IAuthenticationState {


### PR DESCRIPTION
## Overview

Authenticated state was lost when page reloadds

### Notes

Tried loading the user from local storage on app load. Requiring me to use mapStateToProps which did not produce the desired result.

Currently loads the user from local storage at the authentication component level when page is reloaded using componentDidMount.

May be considered as technical debt 

## Testing Instructions

* Sign in
* Reload page
* User data still available