### PR TITLE
Task/parse iframe msgs

### DIFF
--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -36,7 +36,7 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
     const urlParams = new URLSearchParams(window.location.search);
     const base64Token = urlParams.getAll('query')[0];
 
-    if (base64Token) {
+    if (!base64Token) {
       return;
     }
 

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -8,6 +8,7 @@ import * as queryActionCreators from '../../services/actions/query-action-creato
 import './query-runner.scss';
 import { QueryInputControl } from './QueryInput';
 import { Request } from './request/Request';
+import { parse } from './util/iframe-message-parser';
 
 export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState> {
   constructor(props: IQueryRunnerProps) {
@@ -31,10 +32,11 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
   }
 
   public componentDidMount = () => {
+    window.addEventListener('message', this.receiveMessage, false);
     const urlParams = new URLSearchParams(window.location.search);
     const base64Token = urlParams.getAll('query')[0];
 
-    if (!base64Token) {
+    if (base64Token) {
       return;
     }
 
@@ -51,6 +53,34 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
       sampleBody,
       sampleHeaders,
       selectedVerb: sampleVerb,
+    });
+  };
+
+  public componentWillUnmount(): void {
+    window.removeEventListener('message', this.receiveMessage);
+  }
+
+  private receiveMessage = (event: MessageEvent): void => {
+    const {
+      verb,
+      headerKey,
+      headerValue,
+      url,
+      body
+    }: any = parse(event.data);
+
+    if (event.origin !== 'http://docs.microsoft.com' || event.source === null) {
+      return;
+    }
+
+    const headers: any = {};
+    headers[headerKey] = headerValue;
+
+    this.setState({
+      sampleUrl: url,
+      sampleBody: body,
+      sampleHeaders: headers,
+      selectedVerb: verb,
     });
   };
 

--- a/src/app/views/query-runner/util/iframe-message-parser.spec.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.spec.ts
@@ -1,0 +1,72 @@
+import { parse } from './iframe-message-parser';
+
+describe('Iframe Message Parser', () => {
+  it('parses url and verb correctly', () => {
+    const message = `
+    POST https://graph.microsoft.com/v1.0/me/calendars
+    `;
+
+    const parsedMessage = parse(message);
+    expect(parsedMessage).toEqual({
+      verb: 'POST',
+      url: 'https://graph.microsoft.com/v1.0/me/calendars',
+    });
+  });
+
+  it('ignores urls with parameters', () => {
+    const message = `
+    POST https://graph.microsoft.com/v1.0/me/calendars
+    POST https://graph.microsoft.com/v1.0/users/{id | userPrincipalName}/calendars
+    `;
+
+    const parsedMessage = parse(message);
+    expect(parsedMessage).toEqual({
+      verb: 'POST',
+      url: 'https://graph.microsoft.com/v1.0/me/calendars',
+    });
+  });
+
+  it('parses headers correctly', () => {
+    const message = `
+    POST https://graph.microsoft.com/v1.0/me/calendars
+    Content-type: application/json
+    `;
+
+    const parsedMessage = parse(message);
+    expect(parsedMessage).toEqual({
+      verb: 'POST',
+      url: 'https://graph.microsoft.com/v1.0/me/calendars',
+      headerKey: 'Content-type',
+      headerValue: 'application/json',
+    });
+  });
+
+  it('parses body correctly', () => {
+    const message = `
+{ "name": "Volunteer" }
+`;
+
+    const parsedMessage = parse(message);
+    expect(parsedMessage).toEqual({
+      body: '{ "name": "Volunteer" }',
+    });
+  });
+
+  it('parses the whole message correctly', () => {
+    const message = `
+    POST https://graph.microsoft.com/v1.0/me/calendars
+    Content-type: application/json
+    
+{ "name": "Volunteer" }
+`;
+
+    const parsedMessage = parse(message);
+    expect(parsedMessage).toEqual({
+      verb: 'POST',
+      url: 'https://graph.microsoft.com/v1.0/me/calendars',
+      headerKey: 'Content-type',
+      headerValue: 'application/json',
+      body: '{ "name": "Volunteer" }'
+    });
+  });
+});

--- a/src/app/views/query-runner/util/iframe-message-parser.spec.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.spec.ts
@@ -1,4 +1,4 @@
-import { getBody, getHeaders, getUrl, parse } from './iframe-message-parser';
+import { extractBody, extractHeaders, extractUrl, parse } from './iframe-message-parser';
 
 describe('Iframe Message Parser', () => {
   it('parses url and verb correctly', () => {
@@ -6,7 +6,7 @@ describe('Iframe Message Parser', () => {
     POST https://graph.microsoft.com/v1.0/me/calendars
     `;
 
-    const parsedMessage = getUrl(message);
+    const parsedMessage = extractUrl(message);
     expect(parsedMessage).toEqual([
       { verb: 'POST' },
       { url: 'https://graph.microsoft.com/v1.0/me/calendars' }
@@ -23,10 +23,10 @@ Prefer: A-timezone
 
 `;
 
-    const parsedMessage = getHeaders(message);
+    const parsedMessage = extractHeaders(message);
     expect(parsedMessage).toEqual([
-      { 'Content-type': ' application/json' },
-      { 'Prefer': ' A-timezone'}
+      { 'Content-type': 'application/json' },
+      { 'Prefer': 'A-timezone'}
     ]);
   });
 
@@ -35,7 +35,26 @@ Prefer: A-timezone
 { "name": "Volunteer" }
 `;
 
-    const parsedMessage = getBody(message);
+    const parsedMessage = extractBody(message);
     expect(parsedMessage).toEqual('{ "name": "Volunteer" }');
+  });
+
+  it('parses th request snippet correctly', () => {
+    const message = `
+POST https://graph.microsoft.com/v1.0/me/calendars
+Content-type: application/json
+Prefer: A-timezone
+     
+{ "name": "Volunteer" }
+`;
+
+    const parsed = parse(message);
+    expect(parsed).toEqual({
+      verb: 'POST',
+      url: 'https://graph.microsoft.com/v1.0/me/calendars',
+      'Content-type': 'application/json',
+      'Prefer': 'A-timezone',
+      body: '{ "name": "Volunteer" }'
+    });
   });
 });

--- a/src/app/views/query-runner/util/iframe-message-parser.spec.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.spec.ts
@@ -1,4 +1,4 @@
-import { parse } from './iframe-message-parser';
+import { getBody, getHeaders, getUrl, parse } from './iframe-message-parser';
 
 describe('Iframe Message Parser', () => {
   it('parses url and verb correctly', () => {
@@ -6,39 +6,28 @@ describe('Iframe Message Parser', () => {
     POST https://graph.microsoft.com/v1.0/me/calendars
     `;
 
-    const parsedMessage = parse(message);
-    expect(parsedMessage).toEqual({
-      verb: 'POST',
-      url: 'https://graph.microsoft.com/v1.0/me/calendars',
-    });
+    const parsedMessage = getUrl(message);
+    expect(parsedMessage).toEqual([
+      { verb: 'POST' },
+      { url: 'https://graph.microsoft.com/v1.0/me/calendars' }
+    ]);
   });
 
-  it('ignores urls with parameters', () => {
-    const message = `
-    POST https://graph.microsoft.com/v1.0/me/calendars
-    POST https://graph.microsoft.com/v1.0/users/{id | userPrincipalName}/calendars
-    `;
-
-    const parsedMessage = parse(message);
-    expect(parsedMessage).toEqual({
-      verb: 'POST',
-      url: 'https://graph.microsoft.com/v1.0/me/calendars',
-    });
-  });
 
   it('parses headers correctly', () => {
     const message = `
-    POST https://graph.microsoft.com/v1.0/me/calendars
-    Content-type: application/json
-    `;
+POST https://graph.microsoft.com/v1.0/me/calendars
+Content-type: application/json
+Prefer: A-timezone
+     
 
-    const parsedMessage = parse(message);
-    expect(parsedMessage).toEqual({
-      verb: 'POST',
-      url: 'https://graph.microsoft.com/v1.0/me/calendars',
-      headerKey: 'Content-type',
-      headerValue: 'application/json',
-    });
+`;
+
+    const parsedMessage = getHeaders(message);
+    expect(parsedMessage).toEqual([
+      { 'Content-type': ' application/json' },
+      { 'Prefer': ' A-timezone'}
+    ]);
   });
 
   it('parses body correctly', () => {
@@ -46,27 +35,7 @@ describe('Iframe Message Parser', () => {
 { "name": "Volunteer" }
 `;
 
-    const parsedMessage = parse(message);
-    expect(parsedMessage).toEqual({
-      body: '{ "name": "Volunteer" }',
-    });
-  });
-
-  it('parses the whole message correctly', () => {
-    const message = `
-    POST https://graph.microsoft.com/v1.0/me/calendars
-    Content-type: application/json
-    
-{ "name": "Volunteer" }
-`;
-
-    const parsedMessage = parse(message);
-    expect(parsedMessage).toEqual({
-      verb: 'POST',
-      url: 'https://graph.microsoft.com/v1.0/me/calendars',
-      headerKey: 'Content-type',
-      headerValue: 'application/json',
-      body: '{ "name": "Volunteer" }'
-    });
+    const parsedMessage = getBody(message);
+    expect(parsedMessage).toEqual('{ "name": "Volunteer" }');
   });
 });

--- a/src/app/views/query-runner/util/iframe-message-parser.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.ts
@@ -1,0 +1,113 @@
+function isVerb (word: string): boolean {
+  return ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].indexOf(word) !== -1;
+}
+
+function isUrl(word: string): boolean {
+  return word.includes('https') && !word.includes('{');
+}
+
+function isHeaderKey(word: string): boolean {
+  return ['Content-type'].indexOf(word) !== -1;
+}
+
+function isHeaderValue(word: string): boolean {
+  return ['application/json'].indexOf(word) !== -1;
+}
+
+function getBody(payload: string) {
+  const NEWLINE = /\n/;
+  const OPEN_BRACE = /{/;
+  const CLOSING_BRACE = /}/;
+  let current = 1;
+  let word = '';
+
+  while (current < payload.length) {
+    const char = payload[current];
+    const foundNewLine = NEWLINE.test(payload[current - 1]);
+    const foundOpeningBrace = OPEN_BRACE.test(char);
+    const foundClosingBrace = CLOSING_BRACE.test(char);
+
+    if (foundNewLine) {
+      if (foundOpeningBrace) {
+        let start = current;
+
+        while (start < payload.length) {
+          word += payload[start];
+          start++;
+        }
+      }
+    }
+    current++;
+  }
+
+  return word.replace(/\n/g, '');
+}
+
+function tokenize(payload: string) {
+  let word = '';
+  const tokens = [];
+
+  getBody(payload);
+
+  // tslint:disable-next-line
+  for (let i = 0; i < payload.length; i++) {
+    const char = payload[i];
+
+    const SPACE = /\s/;
+    const NEWLINE = /\n/;
+
+    const isDelimeter = SPACE.test(char) || NEWLINE.test(char);
+    word += char;
+
+    if (isDelimeter) {
+
+      word = word.trim();
+      if (isVerb(word)) {
+        tokens.push({
+          verb: word
+        });
+      }
+
+      if (isUrl(word)) {
+        tokens.push({
+          url: word
+        });
+      }
+
+      const sanColon = word.replace(/:/g, '');
+
+      if (isHeaderKey(sanColon)) {
+        tokens.push({
+          headerKey: sanColon
+        });
+      }
+
+      if (isHeaderValue(word)) {
+        tokens.push({
+          headerValue: word
+        });
+      }
+      word = '';
+    }
+
+  }
+
+  const body = getBody(payload);
+
+  if (body) {
+    tokens.push({
+      body
+    });
+  }
+
+
+  return tokens;
+}
+
+export function parse(payload: string): object {
+  const tokens = tokenize(payload);
+
+  return tokens.reduce((obj: object, item: object) => {
+    return {...obj, ...item};
+  }, {});
+}

--- a/src/app/views/query-runner/util/iframe-message-parser.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.ts
@@ -1,4 +1,15 @@
-function isVerb (word: string): boolean {
+// Copyright (c) Microsoft Corporation. All rights reserved.
+// Licensed under the MIT License.
+
+interface IParsedSnippet {
+  verb: string;
+  url: string;
+  headerKey?: string;
+  headerValue?: string;
+  body?: string;
+}
+
+function isVerb(word: string): boolean {
   return ['GET', 'POST', 'PUT', 'PATCH', 'DELETE'].indexOf(word) !== -1;
 }
 
@@ -17,7 +28,6 @@ function isHeaderValue(word: string): boolean {
 function getBody(payload: string) {
   const NEWLINE = /\n/;
   const OPEN_BRACE = /{/;
-  const CLOSING_BRACE = /}/;
   let current = 1;
   let word = '';
 
@@ -25,7 +35,6 @@ function getBody(payload: string) {
     const char = payload[current];
     const foundNewLine = NEWLINE.test(payload[current - 1]);
     const foundOpeningBrace = OPEN_BRACE.test(char);
-    const foundClosingBrace = CLOSING_BRACE.test(char);
 
     if (foundNewLine) {
       if (foundOpeningBrace) {
@@ -43,7 +52,7 @@ function getBody(payload: string) {
   return word.replace(/\n/g, '');
 }
 
-function tokenize(payload: string) {
+function tokenize(payload: string): object[] {
   let word = '';
   const tokens = [];
 
@@ -102,10 +111,10 @@ function tokenize(payload: string) {
   return tokens;
 }
 
-export function parse(payload: string): object {
+export function parse(payload: string): IParsedSnippet | {} {
   const tokens = tokenize(payload);
 
   return tokens.reduce((obj: object, item: object) => {
-    return {...obj, ...item};
+    return { ...obj, ...item };
   }, {});
 }

--- a/src/app/views/query-runner/util/iframe-message-parser.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.ts
@@ -10,7 +10,7 @@ function isUrl(word: string): boolean {
 }
 
 /**
- * In the request snippet the body is represented like below.
+ * In the request snippet the body is represented in the format below.
  * `
  *
  * { name: user}
@@ -58,7 +58,7 @@ export function extractBody(payload: string): string {
 }
 
 /**
- * Headers in a request snippet are represented like below.
+ * Headers in a request snippet are represented in the format below.
  * `
  * POST https://graph.microsoft.com/v1/me
  * Content-type: application/json

--- a/src/app/views/query-runner/util/iframe-message-parser.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.ts
@@ -47,8 +47,6 @@ function tokenize(payload: string) {
   let word = '';
   const tokens = [];
 
-  getBody(payload);
-
   // tslint:disable-next-line
   for (let i = 0; i < payload.length; i++) {
     const char = payload[i];


### PR DESCRIPTION
## Overview

Parses iframe messages to a javascript object.

### Demo

N/A

### Notes

This PR includes a tokenizer that assumes the `body`  of the request in the iframe message is preceded by a newline character.

## Testing Instructions

* Run the tests, observe that they all pass
* Write a test for your own custom message and run tests. It should pass.

Fixes [#48](https://github.com/microsoftgraph/microsoft-graph-explorer-v2/issues/48)