### PR TITLE
Disables focus on Monaco when tabbing

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -1,4 +1,4 @@
-import { classNamesFunction, ITheme, MessageBar, FocusTrapZone, MessageBarType, styled } from 'office-ui-fabric-react';
+import { classNamesFunction, FocusTrapZone, ITheme, MessageBar, MessageBarType, styled } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -1,4 +1,4 @@
-import { classNamesFunction, ITheme, MessageBar, MessageBarType, styled } from 'office-ui-fabric-react';
+import { classNamesFunction, ITheme, MessageBar, FocusTrapZone, MessageBarType, styled } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators, Dispatch } from 'redux';
@@ -22,24 +22,26 @@ class App extends Component<IAppProps> {
     const { error, actions }: any = this.props;
 
     return (
-      <div className={`container-fluid ${classes.app}`}>
-        <div className='row'>
-          <div className='col-sm-12 col-lg-8 offset-lg-2'>
-            <Authentication />
-            <QueryRunner />
-            {error &&
-              <MessageBar
-                messageBarType={MessageBarType.error}
-                isMultiline={false}
-                onDismiss={actions.clearQueryError}
-              >
-                {`${error.statusText} - ${error.status}`}
-              </MessageBar>
-            }
-            <QueryResponse />
+      <FocusTrapZone>
+        <div className={`container-fluid ${classes.app}`}>
+          <div className='row'>
+            <div className='col-sm-12 col-lg-8 offset-lg-2'>
+              <Authentication />
+              <QueryRunner />
+              {error &&
+                <MessageBar
+                  messageBarType={MessageBarType.error}
+                  isMultiline={false}
+                  onDismiss={actions.clearQueryError}
+                >
+                  {`${error.statusText} - ${error.status}`}
+                </MessageBar>
+              }
+              <QueryResponse />
+            </div>
           </div>
         </div>
-      </div>
+      </FocusTrapZone>
     );
   }
 }

--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -1,4 +1,4 @@
-import { FocusZone, getTheme } from 'office-ui-fabric-react'
+import { FocusZone, getTheme } from 'office-ui-fabric-react';
 import React from 'react';
 import MonacoEditor, { ChangeHandler } from 'react-monaco-editor';
 

--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -1,4 +1,4 @@
-import { getTheme } from '@uifabric/styling';
+import { FocusZone, getTheme } from 'office-ui-fabric-react'
 import React from 'react';
 import MonacoEditor, { ChangeHandler } from 'react-monaco-editor';
 
@@ -33,17 +33,19 @@ export function Monaco(props: IMonaco) {
 
 
   return (
-    <div className='monaco-editor'>
-      <MonacoEditor
-        width='800'
-        height='300'
-        value={JSON.stringify(body)}
-        language='json'
-        options={{ lineNumbers: 'off', minimap: { enabled: false } }}
-        editorDidMount={editorDidMount}
-        onChange={onChange}
-        theme={isDark ? 'vs-dark' : 'vs'}
-      />
-    </div>
+    <FocusZone disabled={true}>
+      <div className='monaco-editor'>
+        <MonacoEditor
+          width='800'
+          height='300'
+          value={JSON.stringify(body)}
+          language='json'
+          options={{ lineNumbers: 'off', minimap: { enabled: false } }}
+          editorDidMount={editorDidMount}
+          onChange={onChange}
+          theme={isDark ? 'vs-dark' : 'vs'}
+        />
+      </div>
+    </FocusZone>
   );
 }

--- a/src/app/views/query-runner/QueryInput.tsx
+++ b/src/app/views/query-runner/QueryInput.tsx
@@ -25,6 +25,7 @@ export const QueryInputControl = ({
       </div>
       <div className='col-sm-8'>
         <TextField
+          ariaLabel='Query Sample Input'
           placeholder='Query Sample'
           onChange={(event, value) => handleOnUrlChange(value)}
           defaultValue={sampleUrl}


### PR DESCRIPTION
## Overview

Disables focus on monaco-editor when tabbing through the application

### Demo

N/A

### Notes

Tabbing from one tab element to another doesn't work but users can visit that element using the direction keys. Is this compromise good enough?

## Testing Instructions

* Launch Graph Explorer tab through the application.
* Launch Narrator
* Observe that you can tab through.