### PR TITLE
Feat/show profile picture

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@
 .env.development.local
 .env.test.local
 .env.production.local
+.env
 
 npm-debug.log*
 yarn-debug.log*

--- a/src/app/views/common/image/Image.tsx
+++ b/src/app/views/common/image/Image.tsx
@@ -23,8 +23,7 @@ export class Image extends Component<IImageComponentProps, IImageComponentState>
     const { body } = this.props;
 
     if (body) {
-      const resp = await new Response(body);
-      const buffer = await body.arrayBuffer();
+      const buffer = await body.clone().arrayBuffer();
       const blob = new Blob([buffer], { type: 'image/jpeg' });
       const imageUrl = URL.createObjectURL(blob);
 

--- a/src/app/views/common/image/Image.tsx
+++ b/src/app/views/common/image/Image.tsx
@@ -2,6 +2,7 @@ import React, { Component } from 'react';
 
 interface IImageComponentProps {
   body: any;
+  styles: any;
 }
 
 interface IImageComponentState {
@@ -33,9 +34,10 @@ export class Image extends Component<IImageComponentProps, IImageComponentState>
 
   public render() {
     const { imageUrl } = this.state;
+    const { styles } = this.props;
 
     return (
-      <img src={imageUrl} />
+      <img style={styles} src={imageUrl} />
     );
   }
 }

--- a/src/app/views/common/image/Image.tsx
+++ b/src/app/views/common/image/Image.tsx
@@ -1,17 +1,6 @@
 import React, { Component } from 'react';
+import { IImageComponentProps, IImageComponentState } from '../../../../types/image';
 
-interface IImageComponentProps {
-  body: any;
-  styles: any;
-}
-
-interface IImageComponentState {
-  imageUrl: string;
-}
-
-/**
- * TODO: Support custom styles
- */
 export class Image extends Component<IImageComponentProps, IImageComponentState> {
   constructor(props: any) {
     super(props);
@@ -34,10 +23,10 @@ export class Image extends Component<IImageComponentProps, IImageComponentState>
 
   public render() {
     const { imageUrl } = this.state;
-    const { styles } = this.props;
+    const { styles, alt } = this.props;
 
     return (
-      <img style={styles} src={imageUrl} />
+      <img style={styles} src={imageUrl} alt={alt} />
     );
   }
 }

--- a/src/app/views/common/image/Image.tsx
+++ b/src/app/views/common/image/Image.tsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+
+interface IImageComponentProps {
+  body: any;
+}
+
+interface IImageComponentState {
+  imageUrl: string;
+}
+
+/**
+ * TODO: Support custom styles
+ */
+export class Image extends Component<IImageComponentProps, IImageComponentState> {
+  constructor(props: any) {
+    super(props);
+    this.state = {
+      imageUrl: '',
+    };
+  }
+
+  public async componentDidMount() {
+    const { body } = this.props;
+
+    if (body) {
+      const resp = await new Response(body);
+      const buffer = await body.arrayBuffer();
+      const blob = new Blob([buffer], { type: 'image/jpeg' });
+      const imageUrl = URL.createObjectURL(blob);
+
+      this.setState({ imageUrl });
+    }
+  }
+
+  public render() {
+    const { imageUrl } = this.state;
+
+    return (
+      <img src={imageUrl} />
+    );
+  }
+}

--- a/src/app/views/common/index.ts
+++ b/src/app/views/common/index.ts
@@ -1,1 +1,7 @@
-export { Monaco } from './monaco/Monaco';
+import { Image } from './image/Image';
+import { Monaco } from './monaco/Monaco';
+
+export {
+  Monaco,
+  Image
+};

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -5,6 +5,7 @@ import { connect } from 'react-redux';
 
 import { IQueryResponseProps } from '../../../types/query-response';
 import { Monaco } from '../common';
+import { Image } from '../common/image/Image';
 import './query-response.scss';
 
 class QueryResponse extends Component<IQueryResponseProps, {}> {
@@ -15,6 +16,7 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
   public render() {
     let body;
     let headers;
+    let isImageResponse;
     // @ts-ignore
     const { intl: { messages } } = this.props;
 
@@ -22,6 +24,8 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
     if (graphResponse) {
       body = graphResponse.body;
       headers = graphResponse.headers;
+
+      isImageResponse = body && (body as any).body;
     }
 
     return (
@@ -30,9 +34,14 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
           <PivotItem
             headerText={messages['Response Preview']}
           >
-            <Monaco
-              body={body}
-            />
+            {isImageResponse ?
+              <Image body={body} />
+              :
+              <Monaco
+                body={body}
+              />
+            }
+
           </PivotItem>
           <PivotItem
             headerText={messages['Response Headers']}

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -14,7 +14,7 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
   }
 
   public render() {
-    let body;
+    let body: any;
     let headers;
     let isImageResponse;
     // @ts-ignore
@@ -25,7 +25,9 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
       body = graphResponse.body;
       headers = graphResponse.headers;
 
-      isImageResponse = body && (body as any).body;
+      if (body) {
+        isImageResponse = body && body.body;
+      }
     }
 
     return (

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -37,7 +37,10 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
             headerText={messages['Response Preview']}
           >
             {isImageResponse ?
-              <Image body={body} />
+              <Image
+                styles={{ padding: '10px' }}
+                body={body}
+              />
               :
               <Monaco
                 body={body}

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -4,8 +4,7 @@ import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
 import { IQueryResponseProps } from '../../../types/query-response';
-import { Monaco } from '../common';
-import { Image } from '../common';
+import { Image, Monaco } from '../common';
 import './query-response.scss';
 
 class QueryResponse extends Component<IQueryResponseProps, {}> {

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 
 import { IQueryResponseProps } from '../../../types/query-response';
 import { Monaco } from '../common';
-import { Image } from '../common/image/Image';
+import { Image } from '../common';
 import './query-response.scss';
 
 class QueryResponse extends Component<IQueryResponseProps, {}> {
@@ -44,6 +44,7 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
               <Image
                 styles={{ padding: '10px' }}
                 body={body}
+                alt='profile image'
               />
               :
               <Monaco

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -26,6 +26,10 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
       headers = graphResponse.headers;
 
       if (body) {
+        /**
+         * body.body is a getter propety for the Body mixin. It is used to access the ReadableStream property.
+         * https://developer.mozilla.org/en-US/docs/Web/API/Body/body
+         */
         isImageResponse = body && body.body;
       }
     }

--- a/src/types/image.ts
+++ b/src/types/image.ts
@@ -1,0 +1,9 @@
+export interface IImageComponentProps {
+  body: any;
+  styles: object;
+  alt: string;
+}
+
+export interface IImageComponentState {
+  imageUrl: string;
+}


### PR DESCRIPTION
## Overview

Shows the profile picture when a user queries `/me/photo/$value`

### Demo

![image response](https://user-images.githubusercontent.com/12011447/59586069-aa92b880-90ea-11e9-905b-932e8be3d850.JPG)

### Notes

N/A

## Testing Instructions

* Query `https://graph.microsoft.com/v1.0/me/photo/$value`
* Observe that a profile picture is shown the Response Preview tab

Fixes [#72](https://github.com/microsoftgraph/microsoft-graph-explorer-v2/issues/72)