### PR TITLE
increase key and value width

### DIFF
--- a/src/app/views/query-runner/request/HeadersList.tsx
+++ b/src/app/views/query-runner/request/HeadersList.tsx
@@ -26,9 +26,9 @@ const renderItemColumn = (item: any, index: number | undefined, column: IColumn 
 };
 
 const columns = [
-  { key: 'key', name: 'Key', fieldName: 'name', minWidth: 100, maxWidth: 200 },
-  { key: 'value', name: 'Value', fieldName: 'value', minWidth: 100, maxWidth: 200 },
-  { key: 'button', name: '', fieldName: 'button', minWidth: 100, maxWidth: 200 }
+  { key: 'key', name: 'Key', fieldName: 'name', minWidth: 300, maxWidth: 400 },
+  { key: 'value', name: 'Value', fieldName: 'value', minWidth: 300, maxWidth: 400 },
+  { key: 'button', name: '', fieldName: 'button', minWidth: 200, maxWidth: 300 }
 ];
 
 const headerItems = (headers) ? headers.filter((header) => {


### PR DESCRIPTION


### Demo
<img width="1259" alt="Screen Shot 2019-07-04 at 23 15 03" src="https://user-images.githubusercontent.com/22243090/60686576-4295ed80-9eb2-11e9-9051-4aeb963e17d4.png">


Fix #70 

### Question 
I have increased the minWidth, maxWidth for the columns to get the current results ☝️ 
But I don't think that will solve the issue 100% 

My second approach was to add a class name as seen below 👇 
<img width="908" alt="Screen Shot 2019-07-04 at 23 13 47" src="https://user-images.githubusercontent.com/22243090/60686703-12028380-9eb3-11e9-9f4f-bcff7852a98a.png">

and set the width to 45% like what the issue #70 description suggested 
<img width="393" alt="Screen Shot 2019-07-04 at 23 28 39" src="https://user-images.githubusercontent.com/22243090/60686791-84736380-9eb3-11e9-9e67-7173ed861de6.png"> I know, css in js 😨 

this is what I get 👇 
<img width="1259" alt="Screen Shot 2019-07-04 at 23 10 19" src="https://user-images.githubusercontent.com/22243090/60686850-cf8d7680-9eb3-11e9-865f-f2c5c3350abe.png">

because the parent div doesn't have a width property. 
could someone point me in the right direction?