### PR TITLE
Task/fix http message parser

### DIFF
--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -96,28 +96,28 @@ export class QueryRunner extends Component<IQueryRunnerProps, IQueryRunnerState>
   };
 
   private handleInitMsg = (msg: IInitMessage) => {
-    // const {
-    //   verb,
-    //   headerKey,
-    //   headerValue,
-    //   url,
-    //   body
-    // }: any = parse(msg.code);
+    const {
+      verb,
+      headerKey,
+      headerValue,
+      url,
+      body
+    }: any = parse(msg.code);
 
     // tslint:disable
     console.log(msg);
     console.log(parse(msg.code));
     // tslint:enable
 
-    // const headers: any = {};
-    // headers[headerKey] = headerValue;
-    //
-    // this.setState({
-    //   sampleUrl: url,
-    //   sampleBody: body,
-    //   sampleHeaders: headers,
-    //   selectedVerb: verb,
-    // });
+    const headers: any = {};
+    headers[headerKey] = headerValue;
+
+    this.setState({
+      sampleUrl: url,
+      sampleBody: body,
+      sampleHeaders: headers,
+      selectedVerb: verb,
+    });
   };
 
   private handleThemeChangeMsg = (msg: IThemeChangedMessage) => {

--- a/src/app/views/query-runner/util/iframe-message-parser.spec.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.spec.ts
@@ -1,52 +1,12 @@
-import { extractBody, extractHeaders, extractUrl, parse } from './iframe-message-parser';
+import { parse } from './iframe-message-parser';
 
 describe('Iframe Message Parser', () => {
-  it('parses url and verb correctly', () => {
-    const message = `
-    POST https://graph.microsoft.com/v1.0/me/calendars
-    `;
-
-    const parsedMessage = extractUrl(message);
-    expect(parsedMessage).toEqual([
-      { verb: 'POST' },
-      { url: 'https://graph.microsoft.com/v1.0/me/calendars' }
-    ]);
-  });
-
-
-  it('parses headers correctly', () => {
-    const message = `
-POST https://graph.microsoft.com/v1.0/me/calendars
+  it('parses http request snippet correctly', () => {
+    const message = `POST https://graph.microsoft.com/v1.0/me/calendars
 Content-type: application/json
 Prefer: A-timezone
      
-
-`;
-
-    const parsedMessage = extractHeaders(message);
-    expect(parsedMessage).toEqual([
-      { 'Content-type': 'application/json' },
-      { 'Prefer': 'A-timezone'}
-    ]);
-  });
-
-  it('parses body correctly', () => {
-    const message = `
-{ "name": "Volunteer" }
-`;
-
-    const parsedMessage = extractBody(message);
-    expect(parsedMessage).toEqual('{ "name": "Volunteer" }');
-  });
-
-  it('parses th request snippet correctly', () => {
-    const message = `
-POST https://graph.microsoft.com/v1.0/me/calendars
-Content-type: application/json
-Prefer: A-timezone
-     
-{ "name": "Volunteer" }
-`;
+{ "name": "Volunteer" }`;
 
     const parsed = parse(message);
     expect(parsed).toEqual({

--- a/src/app/views/query-runner/util/iframe-message-parser.ts
+++ b/src/app/views/query-runner/util/iframe-message-parser.ts
@@ -21,7 +21,7 @@ function isUrl(word: string): boolean {
  * 
  * @param payload 
  */
-export function extractBody(payload: string): string {
+function extractBody(payload: string): string {
   const NEWLINE = /\n/;
   const OPEN_BRACE = /{/;
   let current = 1;
@@ -69,7 +69,7 @@ export function extractBody(payload: string): string {
  *
  * @param payload
  */
-export function extractHeaders(payload: string): object[] {
+function extractHeaders(payload: string): object[] {
   const SPACE = /\s/;
   const NEWLINE = /\n/;
 
@@ -120,7 +120,7 @@ export function extractHeaders(payload: string): object[] {
  * tokenize breaks down the snippet payload into the following tokens: verb, url, headerKey, headerValue & body.
  * @param payload 
  */
-export function extractUrl(payload: string) {
+function extractUrl(payload: string) {
   let word = '';
   const result = [];
 
@@ -159,7 +159,9 @@ export function extractUrl(payload: string) {
   return result;
 }
 
-export function parse(payload: string) {
+export function parse(httpRequestMessage: string) {
+  const payload = '\n' + httpRequestMessage + '\n';
+
   const url = extractUrl(payload);
   const headers = extractHeaders(payload);
   const body = extractBody(payload);


### PR DESCRIPTION
## Overview

Suffixes and prefixes a new line to the htpp request message payload.

### Demo

N/A

### Notes

The http request message parser expects the payload to begin and end with a new line. The payload it receives from host origin do not fulfill this requirment, therefore, before parsing the payload with suffix and prefix a new line character.
## Testing Instructions

N/A