### PR TITLE
evenly places controls in request headers component

### DIFF
--- a/src/app/views/query-runner/request/RequestHeaders.tsx
+++ b/src/app/views/query-runner/request/RequestHeaders.tsx
@@ -74,30 +74,28 @@ class RequestHeaders extends Component<IRequestHeadersProps, any> {
 
     return (
       <div className='request-editor-control'>
-        <div className='row'>
-          <div className='headers-editor'>
-            <div>
-              <TextField className='header-input'
-                placeholder={messages.Key}
-                value={this.state.headerName}
-                onChange={(event, name) => this.handleOnHeaderNameChange(name)}
-              />
-            </div>
-            <div>
-              <TextField
-                className='header-input'
-                placeholder={messages.Value}
-                value={this.state.headerValue}
-                onChange={(event, value) => this.handleOnHeaderValueChange(value)}
-              />
-            </div>
-            <div>
-              <PrimaryButton
-                className='header-input-button'
-                onClick={() => this.handleOnHeaderAdd()}>
-                <FormattedMessage id='Add' />
-              </PrimaryButton>
-            </div>
+        <div className='row headers-editor'>
+          <div className='col-sm-5'>
+            <TextField className='header-input'
+              placeholder={messages.Key}
+              value={this.state.headerName}
+              onChange={(event, name) => this.handleOnHeaderNameChange(name)}
+            />
+          </div>
+          <div className='col-sm-5'>
+            <TextField
+              className='header-input'
+              placeholder={messages.Value}
+              value={this.state.headerValue}
+              onChange={(event, value) => this.handleOnHeaderValueChange(value)}
+            />
+          </div>
+          <div className='col-sm-2'>
+            <PrimaryButton
+              className='header-input-button'
+              onClick={() => this.handleOnHeaderAdd()}>
+              <FormattedMessage id='Add' />
+            </PrimaryButton>
           </div>
         </div>
         <br />

--- a/src/app/views/query-runner/request/RequestHeaders.tsx
+++ b/src/app/views/query-runner/request/RequestHeaders.tsx
@@ -92,6 +92,7 @@ class RequestHeaders extends Component<IRequestHeadersProps, any> {
           </div>
           <div className='col-md-4 col-lg-4'>
             <PrimaryButton
+              className='header-input-button'
               onClick={() => this.handleOnHeaderAdd()}>
               <FormattedMessage id='Add' />
             </PrimaryButton>

--- a/src/app/views/query-runner/request/RequestHeaders.tsx
+++ b/src/app/views/query-runner/request/RequestHeaders.tsx
@@ -74,28 +74,30 @@ class RequestHeaders extends Component<IRequestHeadersProps, any> {
 
     return (
       <div className='request-editor-control'>
-        <div className='row headers-editor'>
-          <div className='col-md-4 col-lg-4'>
-            <TextField className='header-input'
-              placeholder={messages.Key}
-              value={this.state.headerName}
-              onChange={(event, name) => this.handleOnHeaderNameChange(name)}
-            />
-          </div>
-          <div className='col-md-4 col-lg-4'>
-            <TextField
-              className='header-input'
-              placeholder={messages.Value}
-              value={this.state.headerValue}
-              onChange={(event, value) => this.handleOnHeaderValueChange(value)}
-            />
-          </div>
-          <div className='col-md-4 col-lg-4'>
-            <PrimaryButton
-              className='header-input-button'
-              onClick={() => this.handleOnHeaderAdd()}>
-              <FormattedMessage id='Add' />
-            </PrimaryButton>
+        <div className='row'>
+          <div className='headers-editor'>
+            <div>
+              <TextField className='header-input'
+                placeholder={messages.Key}
+                value={this.state.headerName}
+                onChange={(event, name) => this.handleOnHeaderNameChange(name)}
+              />
+            </div>
+            <div>
+              <TextField
+                className='header-input'
+                placeholder={messages.Value}
+                value={this.state.headerValue}
+                onChange={(event, value) => this.handleOnHeaderValueChange(value)}
+              />
+            </div>
+            <div>
+              <PrimaryButton
+                className='header-input-button'
+                onClick={() => this.handleOnHeaderAdd()}>
+                <FormattedMessage id='Add' />
+              </PrimaryButton>
+            </div>
           </div>
         </div>
         <br />

--- a/src/app/views/query-runner/request/request.scss
+++ b/src/app/views/query-runner/request/request.scss
@@ -19,19 +19,11 @@
         text-align: center;
         position: relative;
 
-        .row {
-            display: flex;
-            justify-content: center;
-        }
-
         .headers-editor {
-            display: flex;
-            width: '100%';
-            align-items: center;
-            justify-content: space-around;
+            padding: $gutter;
 
-            .header-input {
-                width:450px;
+            .header-input-button {
+                width: 100%;
             }
 
             .remove-header-btn {

--- a/src/app/views/query-runner/request/request.scss
+++ b/src/app/views/query-runner/request/request.scss
@@ -19,17 +19,19 @@
         text-align: center;
         position: relative;
 
+        .row {
+            display: flex;
+            justify-content: center;
+        }
+
         .headers-editor {
-            display: inline-flex;
-            width: 100%;
-            line-height: 5px;
+            display: flex;
+            width: '100%';
+            align-items: center;
+            justify-content: space-around;
 
             .header-input {
-                width:95%;
-            }
-
-            .header-input-button {
-                float: left;
+                width:450px;
             }
 
             .remove-header-btn {
@@ -54,7 +56,4 @@
             }
         }
     }
-
-
-
 }

--- a/src/app/views/query-runner/request/request.scss
+++ b/src/app/views/query-runner/request/request.scss
@@ -28,6 +28,10 @@
                 width:95%;
             }
 
+            .header-input-button {
+                float: left;
+            }
+
             .remove-header-btn {
                 font-size: 25px;
             }


### PR DESCRIPTION

## Overview

Evenly places controls on the screen 
Moves the button closer to the other controls

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Run app
* Head to request headers
* Note that the 'add' button appears closer to the other inputs