### PR TITLE
clears the response component on error

### DIFF
--- a/src/app/services/reducers/query-runner-reducers.ts
+++ b/src/app/services/reducers/query-runner-reducers.ts
@@ -5,6 +5,8 @@ export function graphResponse(state = {}, action: IAction): any {
   switch (action.type) {
     case QUERY_GRAPH_SUCCESS:
       return action.response;
+      case QUERY_GRAPH_ERROR:
+        return { body: {}, headers: {} };
     default:
       return state;
   }

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -45,7 +45,7 @@ class App extends Component<IAppProps, IAppState> {
         <div className={`container-fluid ${classes.app}`}>
           <div className='row'>
             <div className='col-sm-12 col-lg-8 offset-lg-2'>
-              {graphExplorerMode === Mode.Complete && <Authentication />}
+            {graphExplorerMode === Mode.Complete && <Authentication />}
               {graphExplorerMode === Mode.TryIt &&
                 <div style={{ marginBottom: 8 }}>
                   <MessageBar
@@ -59,9 +59,11 @@ class App extends Component<IAppProps, IAppState> {
                   </MessageBar>
                 </div>
               }
-              <QueryRunner
-                onSelectVerb={this.handleSelectVerb}
-              />
+              <div style={{ marginBottom: 8 }}>
+                <QueryRunner
+                  onSelectVerb={this.handleSelectVerb}
+                  />
+              </div>
               {error &&
                 <MessageBar
                   messageBarType={MessageBarType.error}


### PR DESCRIPTION

## Overview

Clears the response component on error

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Setting the response to undefined / null does not affect the response component. 

## Testing Instructions

* Run the profile request "/me"
* Trigger a bad request error e.g "/me/s"
* Notice the previously filled response has an empty object