### PR TITLE
Disables the http version selector for TryIt

### DIFF
--- a/src/app/views/query-runner/QueryInput.tsx
+++ b/src/app/views/query-runner/QueryInput.tsx
@@ -1,7 +1,8 @@
-import { Dropdown, styled, TextField } from 'office-ui-fabric-react';
+import { Dropdown, TextField } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 
+import { Mode } from '../../../types/action';
 import { IQueryInputProps } from '../../../types/query-runner';
 import SubmitButton from '../common/submit-button/SubmitButton';
 
@@ -18,7 +19,8 @@ export class QueryInput extends Component<IQueryInputProps, any> {
       httpMethods,
       selectedVerb,
       sampleUrl,
-      submitting
+      submitting,
+      mode,
     } = this.props;
 
     return (
@@ -29,6 +31,7 @@ export class QueryInput extends Component<IQueryInputProps, any> {
             role='listbox'
             selectedKey={selectedVerb}
             options={httpMethods}
+            disabled={mode === Mode.TryIt}
             onChange={(event, method) => handleOnMethodChange(method)}
           />
         </div>
@@ -59,7 +62,8 @@ function mapStateToProps(state: any) {
   return {
     sampleUrl: state.sampleQuery.sampleUrl,
     selectedVerb: state.sampleQuery.selectedVerb,
-    appTheme: state.theme
+    appTheme: state.theme,
+    mode: state.graphExplorerMode,
   };
 }
 export default connect(

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -1,4 +1,5 @@
 import { ITheme } from '@uifabric/styling';
+import { Mode } from './action';
 
 export interface IQueryRunnerState {
   httpMethods: Array<{ key: string; text: string; }>;
@@ -27,6 +28,7 @@ export interface IQueryRunnerProps {
 export interface IQueryInputProps {
   theme?: ITheme;
   styles?: object;
+  mode?: Mode;
   handleOnRunQuery: Function;
   handleOnMethodChange: Function;
   handleOnUrlChange: Function;


### PR DESCRIPTION
## Overview

Disables the http version selector for customers using Graph Explorer in TryIt mode

### Demo

<img width="1680" alt="Screenshot 2019-09-10 at 11 11 06 AM" src="https://user-images.githubusercontent.com/12011447/64596585-dad1b680-d3bc-11e9-8fa2-ca164c41e985.png">

### Notes

At the moment, customers using graph explorer in TryIt mode only have access to a limited feature set. One of these limitations is that they don't need to change http verbs, therefore, this PR disables the selector control.

## Testing Instructions

* Launch Graph Explorer
* Add the query parameter `?locale=en-us` to activate the TryIt mode
* Observe that the http verb selector is disabled.

Fixes #164 