### PR TITLE
loads queries from cache after first call to api

### DIFF
--- a/src/app/views/sidebar/sample-queries/SampleQueries.tsx
+++ b/src/app/views/sidebar/sample-queries/SampleQueries.tsx
@@ -29,7 +29,12 @@ export class SampleQueries extends Component<ISampleQueriesProps, any> {
   }
 
   public componentDidMount = () => {
-    this.props.actions!.fetchSamples();
+    const { queries } = this.props.samples;
+    if (queries && queries.length > 0) {
+      this.generateSamples(queries);
+    } else {
+      this.props.actions!.fetchSamples();
+    }
   }
 
   public componentDidUpdate = (prevProps: ISampleQueriesProps) => {


### PR DESCRIPTION
## Overview

Previously the samples were loaded every time the samples component was loaded ignoring the fact that the results of the first call to the api actually stored the samples in the store.

This fix checks the contents of the state first and only calls the api when there are no samples in the store

Fixes #170 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Optional. Ancillary topics, caveats, alternative strategies that didn't work out, anything else.

## Testing Instructions

* Load the app
* Notice that it displays 'Loading samples...'
* Change tabs from 'Sample Queries' to 'History' and back
* Notice that it does not display 'Loading samples...'