### PR TITLE
Fix/snippets fetching on keypress

### DIFF
--- a/src/app/views/query-runner/QueryInput.tsx
+++ b/src/app/views/query-runner/QueryInput.tsx
@@ -16,6 +16,7 @@ export class QueryInput extends Component<IQueryInputProps, any> {
       handleOnRunQuery,
       handleOnMethodChange,
       handleOnUrlChange,
+      handleOnBlur,
       httpMethods,
       selectedVerb,
       sampleUrl,
@@ -42,6 +43,7 @@ export class QueryInput extends Component<IQueryInputProps, any> {
             placeholder='Query Sample'
             onChange={(event, value) => handleOnUrlChange(value)}
             defaultValue={sampleUrl}
+            onBlur={() => handleOnBlur()}
           />
         </div>
         <div className='col-sm-2 run-query-button'>

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -81,11 +81,11 @@ export class QueryRunner extends Component<
 
     if (actions) {
       actions.runQuery(sampleQuery);
-    }
+    } 
   };
 
   public render() {
-    const { httpMethods, url } = this.state;
+    const { httpMethods } = this.state;
     const { isLoadingData, sampleQuery } = this.props;
 
     return (

--- a/src/app/views/query-runner/QueryRunner.tsx
+++ b/src/app/views/query-runner/QueryRunner.tsx
@@ -27,7 +27,8 @@ export class QueryRunner extends Component<
         { key: 'PUT', text: 'PUT' },
         { key: 'PATCH', text: 'PATCH' },
         { key: 'DELETE', text: 'DELETE' }
-      ]
+      ],
+      url: ''
     };
   }
 
@@ -45,16 +46,22 @@ export class QueryRunner extends Component<
     }
   };
 
-  private handleOnUrlChange = (newQuery?: string) => {
+  private handleOnUrlChange = (newQuery = '') => {
+    this.setState({ url: newQuery });
+  };
+
+  private handleOnBlur = () => {
+    const { url } = this.state;
     const query = { ...this.props.sampleQuery };
     const { actions } = this.props;
-    if (newQuery) {
-      query.sampleUrl = newQuery;
+
+    if (url) {
+      query.sampleUrl = url;
       if (actions) {
         actions.setSampleQuery(query);
       }
     }
-  };
+  }
 
   private handleOnEditorChange = (body?: string) => {
     this.setState({ sampleBody: body });
@@ -78,7 +85,7 @@ export class QueryRunner extends Component<
   };
 
   public render() {
-    const { httpMethods } = this.state;
+    const { httpMethods, url } = this.state;
     const { isLoadingData, sampleQuery } = this.props;
 
     return (
@@ -89,6 +96,7 @@ export class QueryRunner extends Component<
               handleOnRunQuery={this.handleOnRunQuery}
               handleOnMethodChange={this.handleOnMethodChange}
               handleOnUrlChange={this.handleOnUrlChange}
+              handleOnBlur={this.handleOnBlur}
               httpMethods={httpMethods}
               submitting={isLoadingData}
             />

--- a/src/types/query-runner.ts
+++ b/src/types/query-runner.ts
@@ -4,6 +4,7 @@ import { Mode } from './action';
 export interface IQueryRunnerState {
   httpMethods: Array<{ key: string; text: string; }>;
   sampleBody?: string;
+  url: string;
 }
 
 export interface IQuery {
@@ -32,6 +33,7 @@ export interface IQueryInputProps {
   handleOnRunQuery: Function;
   handleOnMethodChange: Function;
   handleOnUrlChange: Function;
+  handleOnBlur: Function;
   httpMethods: Array<{ key: string; text: string }>;
   selectedVerb: string;
   sampleUrl: string;


### PR DESCRIPTION
## Overview

Requests for code snippets when the url textinput loses focus.

### Demo

N/A

### Notes

Initially, code snippets were fetched every time the `onChange` event was fired. This would have resulted in the api being hit too many times.

## Testing Instructions

* Launch Graph Explorer
* Click on the snippets tab
* Modify the sample url
* Observe that the snippets are fetched only when the sample url textinput control loses focus