### PR TITLE
Feature/adaptive cards

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1515,6 +1515,11 @@
       "resolved": "https://registry.npmjs.org/adaptivecards/-/adaptivecards-1.1.0.tgz",
       "integrity": "sha512-n4vRIjo0vKvjMMnTKqRZm3TXhq+8saN1s17Z0pQEtDpBWjrGbfn8e+Qx/xvgNjqFYzWIme7uZAX3DBDhSOLu/A=="
     },
+    "adaptivecards-templating": {
+      "version": "0.1.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/adaptivecards-templating/-/adaptivecards-templating-0.1.0-alpha.1.tgz",
+      "integrity": "sha512-C5YiUqiOcwlG27aaAEaOQSNAVQK3vBZMJ8ZFa3bCHZktMbbH0EeZZeM/CMu2B+SD0cfIL1tcRr789Ou6lCKrHA=="
+    },
     "address": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "@types/hellojs": "1.16.2",
     "@uifabric/styling": "6.46.0",
     "adaptivecards": "1.1.0",
+    "adaptivecards-templating": "0.1.0-alpha.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",
     "babel-jest": "23.6.0",

--- a/src/messages/en-US.json
+++ b/src/messages/en-US.json
@@ -228,5 +228,5 @@
   "using canary": "You are using the canary version of Graph Explorer. Sign in to make requests",
   "Add": "Add",
   "Snippets": "Snippets",
-  "Adaptive Cards" : "Visual Response"
+  "Adaptive Cards" : "Adaptive Cards"
 }


### PR DESCRIPTION
## Overview

This PR 
- alters the tab name from "Visual Response" to Adaptive Cards.
- moved template population to the client side using the adaptivecards-templating package. Essentially, we now fetch the template then populate from the client rather than having the server populate the template by us sending over data. And therefore, this way we don't send over the data.

### Demo

![image](https://user-images.githubusercontent.com/6464005/65017945-99975480-d930-11e9-8774-6b7c3174e291.png)

## Testing Instructions

* Make a request https://graph.microsoft.com/v1.0/me/ and switch to the Response Visual tab to view the card.
* If a response is not supported the tab will have the message "The Adaptive Card for this response is not available"
