### PR TITLE
removes the loading spinner from the portal

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -26,10 +26,16 @@ import { loadGETheme } from './themes';
 import { Mode } from './types/action';
 import { IHistoryItem } from './types/history';
 
+// removes the loading spinner from GE html after the app is loaded
 const spinner = document.getElementById('spinner');
-
 if (spinner !== null) {
   (spinner as any).parentElement.removeChild(spinner);
+}
+
+// removes the loading spinner from the portal team html after GE loads
+const apiExplorer = document.getElementsByTagName('api-explorer')[0];
+if (apiExplorer && apiExplorer !== null) {
+  (apiExplorer as any).parentElement.removeChild(apiExplorer);
 }
 
 initializeIcons();

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -34,7 +34,7 @@ if (spinner !== null) {
 
 // removes the loading spinner from the portal team html after GE loads
 const apiExplorer = document.getElementsByTagName('api-explorer')[0];
-if (apiExplorer && apiExplorer !== null) {
+if (apiExplorer) {
   (apiExplorer as any).parentElement.removeChild(apiExplorer);
 }
 


### PR DESCRIPTION
## Overview
The loading spinner on the portal does not stop spinning even after the app loads.

Now we check the existence of the html tag `<api-explorer>` that houses the loading spinner on the portal website and remove it from the DOM once Graph explorer is loaded

Fixes #178 

## Testing Instructions

* Log on to the tst environment
* Observe a "starting microsoft graph explorer" spinner
* Notice that it is removed from view after loading is complete