### PR TITLE
Fix/double scroll tst

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6693,11 +6693,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -6714,7 +6716,8 @@
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true
+          "bundled": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
@@ -6843,6 +6846,7 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }

--- a/src/app/views/App.styles.ts
+++ b/src/app/views/App.styles.ts
@@ -7,9 +7,7 @@ export const appStyles = (theme: ITheme) => {
       background: theme.semanticColors.bodyBackground,
       color: theme.semanticColors.bodyText,
       paddingTop: theme.spacing.s1,
-      width: '100%',
-      height: '1024px',
-      overflow: 'scroll'
+      width: '100%'
     },
     tryItMessage: {
       marginBottom: theme.spacing.s1

--- a/src/app/views/query-runner/request/request.scss
+++ b/src/app/views/query-runner/request/request.scss
@@ -4,7 +4,7 @@
     width:100%;
     margin-top: $gutter;
     margin-bottom: $gutter;
-    min-height: 370px;
+    height: 350px;
     border: 1px solid silver;
     overflow: hidden;
 


### PR DESCRIPTION
## Overview

Reduces the height of the request editor so that Graph Explorer can fit into the available 'viewport' when hosted within the portal.

### Demo

N/A

### Notes

In [this PR](https://github.com/microsoftgraph/microsoft-graph-explorer-v2/pull/232) I tried setting the height to `1024px` and then adding an overflow property. This worked as far as preventing Graph Explorer from overflowing. The caveat was that, the user would have to scroll twice. So I decided against that implementation.

This implementation reduces the size of the request editor so that Graph Explorer fits in the portal without overflowing.

## Testing Instructions

N/A

Fixes #216 