### PR TITLE
Set up monaco editor workers proxy

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -110,6 +110,31 @@ readData().then((data: any) => {
   }
 });
 
+/**
+ * Set's up Monaco Editor's Workers.
+ */
+enum Workers {
+  Json = 'json',
+  Editor = 'editor'
+}
+
+(window as any).MonacoEnvironment = {
+  getWorkerUrl (moduleId: any, label: string) {
+    if (label === 'json') {
+      return getWorkerFor(Workers.Json);
+    }
+    return getWorkerFor(Workers.Editor);
+  }
+};
+
+function getWorkerFor(worker: string): string {
+  const WORKER_PATH = 'https://personalize.blob.core.windows.net/test';
+
+  return `data:text/javascript;charset=utf-8,${encodeURIComponent(`
+	    importScripts('${WORKER_PATH}/${worker}.worker.js');`
+  )}`;
+}
+
 const Root = () => {
   return (
     <Provider store={appState}>


### PR DESCRIPTION
## Overview

Fixes monaco formatting bug in the -tst environment.

### Demo

N/A

### Notes

The bug was caused by monaco trying to load workers from a non server environment. GE is hosted in portal as a JS bundle. 

## Testing Instructions

N/A