### PR TITLE
Fix displaying of cards on error response

### DIFF
--- a/src/app/services/actions/adaptive-cards-action-creator.ts
+++ b/src/app/services/actions/adaptive-cards-action-creator.ts
@@ -37,6 +37,11 @@ export function getAdaptiveCard(payload: string, sampleQuery: IQuery): Function 
       return dispatch(getAdaptiveCardSuccess());
     }
 
+    if (Object.keys(payload).length === 0) {
+      // check if the payload is something else that we cannot use
+      return dispatch(getAdaptiveCardError('Invalid payload for card'));
+    }
+
     const templateFileName = lookupTemplate(sampleQuery);
     if (!templateFileName) {
       // we dont support this card yet
@@ -74,7 +79,7 @@ function lookupTemplate(sampleQuery: IQuery): string {
     for (const templateMapKey in templateMap) {
       if (templateMap.hasOwnProperty(templateMapKey)) {
         // check if the template matches a specific pattern while ignoring case
-        const isMatch = new RegExp(templateMapKey + '$', 'i').test(query);
+        const isMatch = new RegExp(templateMapKey + '$', 'i').test('/' + query);
         if (isMatch) {
           return templateMap[templateMapKey];
         }
@@ -85,16 +90,16 @@ function lookupTemplate(sampleQuery: IQuery): string {
 }
 
 const templateMap: any = {
-  'groups' : 'Groups.json',
-  'me': 'Profile.json',
-  'me/directReports' : 'Users.json',
-  'me/drive/root/children': 'Files.json',
-  'me/drive/recent' : 'Files.json',
-  'me/manager': 'Profile.json',
-  'me/memberOf' : 'Groups.json',
-  'me/messages' : 'Messages.json',
-  'sites/([^/]+)' : 'Site.json',
-  'sites/([^/]+)/sites' : 'Sites.json',
-  'users' : 'Users.json',
-  'users/([^/]+)' : 'Profile.json'
+  '/groups' : 'Groups.json',
+  '/me': 'Profile.json',
+  '/me/directReports' : 'Users.json',
+  '/me/drive/root/children': 'Files.json',
+  '/me/drive/recent' : 'Files.json',
+  '/me/manager': 'Profile.json',
+  '/me/memberOf' : 'Groups.json',
+  '/me/messages' : 'Messages.json',
+  '/sites/([^/?]+)' : 'Site.json',
+  '/sites/([^/?]+)/sites' : 'Sites.json',
+  '/users' : 'Users.json',
+  '/users/([^/?]+)' : 'Profile.json'
 };


### PR DESCRIPTION
## Overview

This Pr updates the checks for the response body to prevent the attempt to render cards when the response is invalid.

The template map has also been updated to fix potential issues with request mappings. 
The '/' is added to perform better matching so that we don't try to get a template if the url simply has the phrase 'me'.

### Demo
![image](https://user-images.githubusercontent.com/6464005/67095919-bc32bc80-f1bf-11e9-886a-89cfe1ff2958.png)

## Testing Instructions

* Perform a request on that returns a 404 error
* You should see the message "Adaptive card for this Response is not available"