### PR TITLE
Updates how scopes values are retrieved

### DIFF
--- a/src/app/services/actions/permissions-action-creator.ts
+++ b/src/app/services/actions/permissions-action-creator.ts
@@ -73,7 +73,7 @@ export function getConsent(): Function {
     for (let num = 0; num < scopes.length; num++) {
 
       const scope: string[] = [];
-      scope.push(scopes[num]);
+      scope.push(scopes[num].value);
 
       try {
         const response = await authenticatedRequest(dispatch, query, scope);


### PR DESCRIPTION
## Overview

Updates how scope values are consumed as they will be returned as an array of objects from the Permissions API.

### Demo

Given a sample request for example: 
`/api/GraphExplorerPermissions?requesturl=/me/memberof&method=GET&scopetype=DelegatedWork`

The returned scopes will be of the format:
`[ { "value":"Directory.Read.All", "consentDisplayName":"Read directory data", "consentDescription":"Allows the app to read data in your organization's directory.", "isAdmin":true }, { "value":"Directory.ReadWrite.All", "consentDisplayName":"Read and write directory data", "consentDescription":"Allows the app to read and write data in your organization's directory, such as other users, groups. It does not allow the app to delete users or groups, or reset user passwords.","isAdmin":true},{"value":"Directory.AccessAsUser.All","consentDisplayName":"Access the directory as you","consentDescription":"Allows the app to have the same access to information in your work or school directory as you do.", "isAdmin":true } ]`


### Notes

The Permissions API endpoint currently has the default implementation though as is, but this PR https://github.com/microsoftgraph/microsoft-graph-explorer-api/pull/136 will push the above proposed changes.

## Testing Instructions

Testing can be done once the dependent PR has been merged and changes pushed to the requisite `master` branch.