### PR TITLE
fixes local samples ordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "@svgr/webpack": "4.1.0",
     "@uifabric/react-cards": "0.108.2",
     "@uifabric/styling": "6.46.0",
-    "adaptivecards": "1.1.0",
+    "adaptivecards": "1.2.3",
     "adaptivecards-templating": "0.1.0-alpha.1",
     "babel-core": "7.0.0-bridge.0",
     "babel-eslint": "9.0.0",

--- a/src/app/views/sidebar/sample-queries/queries.ts
+++ b/src/app/views/sidebar/sample-queries/queries.ts
@@ -260,6 +260,38 @@ export const queries: ISampleQuery[]  = [
       "docLink": "https://developer.microsoft.com/en-us/graph/docs/concepts/delta_query_messages",
       "skipTest": false
   },
+    {
+        "category": "Outlook Mail",
+        "method": "GET",
+        "humanName": "my outlook categories",
+        "requestUrl": "/beta/me/outlook/masterCategories",
+        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/outlookuser_list_mastercategories",
+        "skipTest": false
+    },
+    {
+        "category": "Outlook Mail",
+        "method": "GET",
+        "humanName": "get email headers",
+        "requestUrl": "/beta/me/messages?$select=internetMessageHeaders&$top=1",
+        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/message",
+        "skipTest": false
+    },
+    {
+        "category": "Outlook Mail",
+        "method": "GET",
+        "humanName": "list conference rooms",
+        "requestUrl": "/beta/me/findRooms",
+        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/user_findrooms",
+        "skipTest": false
+    },
+    {
+        "category": "Outlook Mail",
+        "method": "GET",
+        "humanName": "my inbox rules",
+        "requestUrl": "/beta/me/mailFolders/inbox/messagerules",
+        "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/messagerule",
+        "skipTest": false
+    },
   {
       "category": "Outlook Mail (beta)",
       "method": "GET",
@@ -1093,38 +1125,6 @@ export const queries: ISampleQuery[]  = [
       "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/channel_post_chatthreads",
       "postBody": "{\r\n\"rootMessage\": {\r\n       \"body\": {\r\n         \"contentType\": 2,\r\n         \"content\": \"Hello world\"\r\n       }\r\n   }\r\n }",
       "tip": "This query requires a team id and a channel id from that team. To find the team id  & channel id, you can run: 1) GET https://graph.microsoft.com/beta/me/joinedTeams 2) GET https://graph.microsoft.com/beta/teams/{team-id}/channels",
-      "skipTest": false
-  },
-  {
-      "category": "Outlook Mail",
-      "method": "GET",
-      "humanName": "my inbox rules",
-      "requestUrl": "/beta/me/mailFolders/inbox/messagerules",
-      "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/messagerule",
-      "skipTest": false
-  },
-  {
-      "category": "Outlook Mail",
-      "method": "GET",
-      "humanName": "my outlook categories",
-      "requestUrl": "/beta/me/outlook/masterCategories",
-      "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/outlookuser_list_mastercategories",
-      "skipTest": false
-  },
-  {
-      "category": "Outlook Mail",
-      "method": "GET",
-      "humanName": "get email headers",
-      "requestUrl": "/beta/me/messages?$select=internetMessageHeaders&$top=1",
-      "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/resources/message",
-      "skipTest": false
-  },
-  {
-      "category": "Outlook Mail",
-      "method": "GET",
-      "humanName": "list conference rooms",
-      "requestUrl": "/beta/me/findRooms",
-      "docLink": "https://developer.microsoft.com/en-us/graph/docs/api-reference/beta/api/user_findrooms",
       "skipTest": false
   },
   {


### PR DESCRIPTION
## Overview

Investigates the reason why Microsoft Teams (beta) samples were loading samples unrelated to teams.
Fixes the issue in the local version of the queries

Fixes #249 

### Notes

Changes on the api providing the samples has been done on a branch in the repository
[PR 139](https://github.com/microsoftgraph/microsoft-graph-explorer-api/pull/139)

## Testing Instructions

* How to test this PR
* Prefer bulleted description
* Start after checking out this branch
* Include any setup required, such as bundling scripts, restarting services, etc.
* Include test case, and expected output