### PR TITLE
Feat/hide login edge

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -208,6 +208,7 @@ class App extends Component<IAppProps, IAppState> {
     const isEdge = msedge > 0;
     return isEdge;
   }
+
   public optOut = () => {
     const path = location.href;
     const urlObject: URL = new URL(path);

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -301,7 +301,7 @@ class App extends Component<IAppProps, IAppState> {
                       <p>Sign in not supported on this browser, please use
                         <a className={classes.links}
                           tabIndex={0}
-                          href='https://www.microsoftedgeinsider.com/en-us/welcome?channel=dev' target='_blank'>
+                          href='https://www.microsoftedgeinsider.com/en-us/download' target='_blank'>
                           EdgeDev.
                         </a>
                       </p>

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -298,7 +298,13 @@ class App extends Component<IAppProps, IAppState> {
                     <MessageBar
                       messageBarType={MessageBarType.warning}
                     >
-                      <p>Authentication is not supported in Edge. Use EdgeDev.</p>
+                      <p>Sign in not supported on this browser, please use
+                        <a className={classes.links}
+                          tabIndex={0}
+                          href='https://www.microsoftedgeinsider.com/en-us/welcome?channel=dev' target='_blank'>
+                          EdgeDev.
+                        </a>
+                      </p>
                     </MessageBar>
                   </div>
                 : !showToggle && <><Authentication />

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -199,14 +199,14 @@ class App extends Component<IAppProps, IAppState> {
     this.props.actions!.toggleSidebar(properties);
   }
 
-  public userIsOnEdge() {
+  public userIsOnEdgeOrIE() {
     const ua = window.navigator.userAgent;
     const msie = ua.indexOf('MSIE ');
     const msie11 = ua.indexOf('Trident/');
     const msedge = ua.indexOf('Edge/');
     const isIE = msie > 0 || msie11 > 0;
     const isEdge = msedge > 0;
-    return isEdge;
+    return isEdge || isIE;
   }
 
   public optOut = () => {
@@ -226,7 +226,7 @@ class App extends Component<IAppProps, IAppState> {
     const historyHeaderText = messages['History'];
     const { showToggle, showSidebar } = sidebarProperties;
     const language = navigator.language  || 'en-US';
-    const onEdge = this.userIsOnEdge();
+    const onEdgeOrIE = this.userIsOnEdgeOrIE();
 
     let displayContent = true;
     if (graphExplorerMode === Mode.Complete) {
@@ -293,7 +293,7 @@ class App extends Component<IAppProps, IAppState> {
 
 
                   <hr className={classes.separator} />
-                {onEdge ?
+                {onEdgeOrIE ?
                   <div style={{ marginBottom: 8 }}>
                     <MessageBar
                       messageBarType={MessageBarType.warning}

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -199,6 +199,15 @@ class App extends Component<IAppProps, IAppState> {
     this.props.actions!.toggleSidebar(properties);
   }
 
+  public userIsOnEdge() {
+    const ua = window.navigator.userAgent;
+    const msie = ua.indexOf('MSIE ');
+    const msie11 = ua.indexOf('Trident/');
+    const msedge = ua.indexOf('Edge/');
+    const isIE = msie > 0 || msie11 > 0;
+    const isEdge = msedge > 0;
+    return isEdge;
+  }
   public optOut = () => {
     const path = location.href;
     const urlObject: URL = new URL(path);
@@ -216,6 +225,7 @@ class App extends Component<IAppProps, IAppState> {
     const historyHeaderText = messages['History'];
     const { showToggle, showSidebar } = sidebarProperties;
     const language = navigator.language  || 'en-US';
+    const onEdge = this.userIsOnEdge();
 
     let displayContent = true;
     if (graphExplorerMode === Mode.Complete) {
@@ -261,7 +271,7 @@ class App extends Component<IAppProps, IAppState> {
                         marginLeft: '70%',
                       }}>
 
-                      <Authentication />
+                        <Authentication />
                       </span>
                       </>
                 </Stack>
@@ -282,7 +292,16 @@ class App extends Component<IAppProps, IAppState> {
 
 
                   <hr className={classes.separator} />
-                  {!showToggle && <><Authentication /> <hr className={classes.separator} /></> }
+                {onEdge ?
+                  <div style={{ marginBottom: 8 }}>
+                    <MessageBar
+                      messageBarType={MessageBarType.warning}
+                    >
+                      <p>Authentication is not supported in Edge. Use EdgeDev.</p>
+                    </MessageBar>
+                  </div>
+                : !showToggle && <><Authentication />
+                   <hr className={classes.separator} /></> }
 
                   {showSidebar && <>
                     <Banner optOut={this.optOut} />


### PR DESCRIPTION
## Overview

Hides authentication button in Edge/IE

### Demo

Optional. Screenshots, `curl` examples, etc.
![image](https://user-images.githubusercontent.com/12011447/67668017-2dbcf880-f980-11e9-9fbf-02a5eb2c6a84.png)

### Notes

Authentication is disabled because msal breaks when `acquireTokenPopUp` is called in Edge. We also. can't switch to using redirect because it will break the incremental consent feature.

## Testing Instructions

* Launch GE in Edge
* Observe that you can't log in