### PR TITLE
Calls setConsent to mscc

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -83,6 +83,9 @@
   </div>
   <noscript>You need to enable JavaScript to run this app.</noscript>
   <div id="root"></div>
+  <script>
+    window.mscc = mscc
+  </script>
 </body>
 
 </html>

--- a/src/app/views/authentication/Authentication.tsx
+++ b/src/app/views/authentication/Authentication.tsx
@@ -17,6 +17,12 @@ export class Authentication extends Component<IAuthenticationProps> {
   }
 
   public signIn = async (): Promise<void> => {
+    const { mscc } = (window as any);
+
+    if (mscc) {
+      mscc.setConsent();
+    }
+
     const authResponse = await logIn();
     if (authResponse) {
       this.props.actions!.signIn(authResponse.accessToken);
@@ -46,8 +52,8 @@ export class Authentication extends Component<IAuthenticationProps> {
             iconProps={{ iconName: 'Contact' }}
             onClick={this.signIn}
           >
-        {!mobileScreen && <FormattedMessage id='sign in' />}
-        </PrimaryButton>}
+            {!mobileScreen && <FormattedMessage id='sign in' />}
+          </PrimaryButton>}
         {tokenPresent && <Profile />}
       </Stack.Item>
     </Stack>;
@@ -57,16 +63,16 @@ export class Authentication extends Component<IAuthenticationProps> {
       <div className={classes.authenticationContainer}>
         {!mobileScreen && <Stack>
           {!tokenPresent &&
-          <>
-            <Label style={authLabel}>
-              <Icon iconName='Permissions' style={authIcon} />
-              <FormattedMessage id='Authentication'/>
-            </Label>
-            <br />
-            <Label>
-              <FormattedMessage id='Using demo tenant' /> <FormattedMessage id='To access your own data:' />
-            </Label>
-          </>
+            <>
+              <Label style={authLabel}>
+                <Icon iconName='Permissions' style={authIcon} />
+                <FormattedMessage id='Authentication' />
+              </Label>
+              <br />
+              <Label>
+                <FormattedMessage id='Using demo tenant' /> <FormattedMessage id='To access your own data:' />
+              </Label>
+            </>
           }
           <span><br />{authenticationStack}<br /> </span>
         </Stack>}


### PR DESCRIPTION
## Overview

1. Traps the mscc object and stores it in the window variable.
2. Calls setConsent on the mscc object.

### Demo

N/A

### Notes

The mscc needs to be put in a window object so that it can be accessed from a React object.

## Testing Instructions

N/A