### PR TITLE
Updating Mispelled JavaScript

### DIFF
--- a/src/app/views/query-response/snippets/Snippets.tsx
+++ b/src/app/views/query-response/snippets/Snippets.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { renderSnippets } from './snippets-helper';
 
 export function Snippets() {
-  const supportedLanguages = ['CSharp', 'Javascript', 'Java', 'Objective-C'];
+  const supportedLanguages = ['CSharp', 'JavaScript', 'Java', 'Objective-C'];
 
   return (
     <Pivot>


### PR DESCRIPTION
"Javascript" should be uppercase "S". Tested to make sure case sensitivity wasn't a problem with loading the language for Monaco.


## Overview

Updating the snippet pivot text "Javascript" to "JavaScript".

### Notes

I've updated the S in Javascript to be JavaScript in the Snippets component for the language Pivot control. Tested to make sure case sensitivity wouldn't be a problem with the monaco editor.

## Testing Instructions

Load the Graph Explorer, make a sample call from the left sample queries panel. Open the "Snippets"  Pivot, and load "JavaScript" pivot.
