### PR TITLE
Feat/show tick icon

### DIFF
--- a/src/app/views/query-runner/request/auth/Auth.tsx
+++ b/src/app/views/query-runner/request/auth/Auth.tsx
@@ -1,4 +1,4 @@
-import { IconButton, IIconProps, Label, PrimaryButton, styled } from 'office-ui-fabric-react';
+import { IconButton, IIconProps, Label, styled } from 'office-ui-fabric-react';
 import React from 'react';
 import { FormattedMessage } from 'react-intl';
 import { useSelector } from 'react-redux';

--- a/src/app/views/query-runner/request/permissions/Permission.styles.ts
+++ b/src/app/views/query-runner/request/permissions/Permission.styles.ts
@@ -25,6 +25,10 @@ export const permissionStyles = (theme: ITheme) => {
     },
     permissions: {
       marginBottom: 120
+    },
+    checkIcon: {
+      fontSize: theme.fonts.large,
+      color: theme.palette.accent
     }
   };
 };

--- a/src/app/views/query-runner/request/permissions/Permission.tsx
+++ b/src/app/views/query-runner/request/permissions/Permission.tsx
@@ -3,6 +3,7 @@ import {
   DetailsListLayoutMode,
   getId,
   IColumn,
+  Icon,
   Label,
   PrimaryButton,
   SelectionMode,
@@ -56,7 +57,6 @@ function Permission(props: any) {
   }
 
   const classes = classNames(props);
-
   useEffect(() => {
     setLoading(true);
     setPermissions([]);
@@ -97,9 +97,9 @@ function Permission(props: any) {
 
         case 'isAdmin':
           if (item.isAdmin) {
-            return 'True';
+            return <Icon iconName='checkmark' className={classes.checkIcon} />;
           } else {
-            return 'False';
+            return '';
           }
 
         case 'consented':

--- a/src/app/views/sidebar/sample-queries/tokens.ts
+++ b/src/app/views/sidebar/sample-queries/tokens.ts
@@ -1,3 +1,4 @@
+// @ts-ignore
 import { Guid } from 'guid-typescript';
 import { IToken } from '../../../../types/sidebar';
 


### PR DESCRIPTION
## Overview

Shows tick Icon instead of the word True in the permissions tab.

### Demo

![image](https://user-images.githubusercontent.com/12011447/68764871-9537a100-062c-11ea-93dd-9734f5f7a0f4.png)

### Notes

N/A

## Testing Instructions

* Start GE
* Click on the permissions tab
* Observe the tick icons in the `Admin Consent` column

Closes #281 