### PR TITLE
Feat/backward compatible share queries

### DIFF
--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -65,7 +65,6 @@ class App extends Component<IAppProps, IAppState> {
     this.displayToggleButton(this.mediaQueryList);
     this.mediaQueryList.addListener(this.displayToggleButton);
 
-    const { actions } = this.props;
     const whiteListedDomains = [
       'https://docs.microsoft.com',
       'https://review.docs.microsoft.com',
@@ -84,6 +83,39 @@ class App extends Component<IAppProps, IAppState> {
 
     // Listens for messages from host document
     window.addEventListener('message', this.receiveMessage, false);
+    this.handleSharedQueries();
+    this.handleSharedV3Queries();
+  };
+
+  public handleSharedV3Queries() {
+    const { actions } = this.props;
+    const queryStringParams = this.getQueryStringParams();
+    const query = this.generateQueryObjectFrom(queryStringParams);
+    actions!.setSampleQuery(query);
+  }
+
+  private getQueryStringParams() {
+    const urlParams = new URLSearchParams(window.location.search);
+
+    const request = urlParams.get('request');
+    const method = urlParams.get('method');
+    const version = urlParams.get('version');
+    const graphUrl = urlParams.get('GraphUrl');
+
+    return { request, method, version, graphUrl };
+  }
+
+  private generateQueryObjectFrom(queryParams: any) {
+    const { request, method, version, graphUrl } = this.getQueryStringParams();
+    return {
+      sampleUrl: `${graphUrl}/${version}/${request}`,
+      selectedVerb: method,
+      selectedVersion: version
+    };
+  }
+
+  public handleSharedQueries() {
+    const { actions } = this.props;
 
     const urlParams = new URLSearchParams(window.location.search);
     const base64Token = urlParams.getAll('query')[0];
@@ -105,7 +137,7 @@ class App extends Component<IAppProps, IAppState> {
     if (actions) {
       actions.setSampleQuery(query);
     }
-  };
+  }
 
   public componentWillUnmount(): void {
     window.removeEventListener('message', this.receiveMessage);

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -126,8 +126,8 @@ class App extends Component<IAppProps, IAppState> {
     };
   }
 
-  private hashDecode(requestBody: string) {
-    return atob(requestBody);
+  private hashDecode(requestBody: string): string {
+    return requestBody ? atob(requestBody) : '';
   }
 
   public componentWillUnmount(): void {

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -93,7 +93,10 @@ class App extends Component<IAppProps, IAppState> {
     const query = this.generateQueryObjectFrom(queryStringParams);
 
     if (query) {
-      actions!.setSampleQuery(query);
+      // This timeout waits for monaco to initialize it's formatter.
+      setTimeout(() => {
+        actions!.setSampleQuery(query);
+      }, 700);
     }
   }
 
@@ -119,8 +122,12 @@ class App extends Component<IAppProps, IAppState> {
       sampleUrl: `${graphUrl}/${version}/${request}`,
       selectedVerb: method,
       selectedVersion: version,
-      sampleBody: requestBody
+      sampleBody: this.hashDecode(requestBody)
     };
+  }
+
+  private hashDecode(requestBody: string) {
+    return atob(requestBody);
   }
 
   public componentWillUnmount(): void {

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -10,6 +10,7 @@ import { loadGETheme } from '../../themes';
 import { ThemeContext } from '../../themes/theme-context';
 import { Mode } from '../../types/action';
 import { IInitMessage, IThemeChangedMessage } from '../../types/query-runner';
+import { ISharedQueryParams } from '../../types/share-query';
 import { ISidebarProps } from '../../types/sidebar';
 import { runQuery } from '../services/actions/query-action-creators';
 import { setSampleQuery } from '../services/actions/query-input-action-creators';
@@ -96,7 +97,7 @@ class App extends Component<IAppProps, IAppState> {
     }
   }
 
-  private getQueryStringParams() {
+  private getQueryStringParams(): ISharedQueryParams {
     const urlParams = new URLSearchParams(window.location.search);
 
     const request = urlParams.get('request');

--- a/src/app/views/App.tsx
+++ b/src/app/views/App.tsx
@@ -84,14 +84,16 @@ class App extends Component<IAppProps, IAppState> {
     // Listens for messages from host document
     window.addEventListener('message', this.receiveMessage, false);
     this.handleSharedQueries();
-    this.handleSharedV3Queries();
   };
 
-  public handleSharedV3Queries() {
+  public handleSharedQueries() {
     const { actions } = this.props;
     const queryStringParams = this.getQueryStringParams();
     const query = this.generateQueryObjectFrom(queryStringParams);
-    actions!.setSampleQuery(query);
+
+    if (query) {
+      actions!.setSampleQuery(query);
+    }
   }
 
   private getQueryStringParams() {
@@ -101,42 +103,23 @@ class App extends Component<IAppProps, IAppState> {
     const method = urlParams.get('method');
     const version = urlParams.get('version');
     const graphUrl = urlParams.get('GraphUrl');
+    const requestBody = urlParams.get('requestBody');
 
-    return { request, method, version, graphUrl };
+    return { request, method, version, graphUrl, requestBody };
   }
 
   private generateQueryObjectFrom(queryParams: any) {
-    const { request, method, version, graphUrl } = this.getQueryStringParams();
+    const { request, method, version, graphUrl, requestBody } = queryParams;
+    if (!request) {
+      return null;
+    }
+
     return {
       sampleUrl: `${graphUrl}/${version}/${request}`,
       selectedVerb: method,
-      selectedVersion: version
+      selectedVersion: version,
+      sampleBody: requestBody
     };
-  }
-
-  public handleSharedQueries() {
-    const { actions } = this.props;
-
-    const urlParams = new URLSearchParams(window.location.search);
-    const base64Token = urlParams.getAll('query')[0];
-
-    if (!base64Token) {
-      return;
-    }
-
-    const data = JSON.parse(atob(base64Token));
-    const { sampleVerb, sampleHeaders, sampleUrl, sampleBody } = data;
-
-    const query = {
-      sampleUrl,
-      sampleBody,
-      sampleHeaders,
-      selectedVerb: sampleVerb
-    };
-
-    if (actions) {
-      actions.setSampleQuery(query);
-    }
   }
 
   public componentWillUnmount(): void {

--- a/src/app/views/common/monaco/Monaco.tsx
+++ b/src/app/views/common/monaco/Monaco.tsx
@@ -48,7 +48,7 @@ export function Monaco(props: IMonaco) {
             width='800 !important'
             height={verbIsGet ? '80vh' : '350px'}
             // @ts-ignore
-            value={body  ? body : ''}
+            value={body ? body : ''}
             language={language ? language : 'json'}
             options={{
               lineNumbers: 'off',

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -46,8 +46,7 @@ class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialo
 
   private generateShareQueryParams = (): string => {
     const { sampleQuery: { sampleBody, sampleUrl, selectedVerb, selectedVersion } } = this.props;
-    const origin = window.location.origin;
-    const pathname = window.location.pathname;
+    const { origin, pathname } = window.location;
     const url = new URL(sampleUrl);
     const graphUrl = url.origin;
     /**

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,4 +1,4 @@
-import { DefaultButton, IconButton, Pivot, PivotItem, PrimaryButton, } from 'office-ui-fabric-react';
+import { DefaultButton, FontSizes, IconButton, Pivot, PivotItem, PrimaryButton, } from 'office-ui-fabric-react';
 import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
@@ -21,6 +21,18 @@ class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialo
       showShareQueryDialog: true,
       query: '',
     };
+  }
+
+  public handleCopy = () => {
+    const shareQueryParams: any = document.getElementById('share-query-text');
+    shareQueryParams.focus();
+    shareQueryParams.select();
+
+    document.execCommand('copy');
+    document.execCommand('unselect');
+
+    shareQueryParams.blur();
+    this.toggleShareQueryDialogState();
   }
 
   public handleShareQuery = () => {
@@ -152,11 +164,18 @@ class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialo
             subText: messages['Share Query Message']
           }}
         >
-          <p className='share-query-params'>
-            {query}
-          </p>
+          <textarea style={{
+            wordWrap: 'break-word',
+            fontFamily: 'monospace',
+            fontSize: FontSizes.xSmall,
+            width: '100%',
+            height: 63,
+            overflowY: 'scroll',
+            border: 'none',
+            resize: 'none'
+          }} className='share-query-params' id='share-query-text' defaultValue={query} />
           <DialogFooter>
-            <PrimaryButton text='Copy' />
+            <PrimaryButton text='Copy' onClick={this.handleCopy} />
             <DefaultButton text='Close' onClick={this.toggleShareQueryDialogState} />
           </DialogFooter>
         </Dialog>

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -45,21 +45,22 @@ class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialo
   }
 
   private generateShareQueryParams = (): string => {
-    const { sampleQuery } = this.props;
+    const { sampleQuery: { sampleBody, sampleUrl, selectedVerb, selectedVersion } } = this.props;
     const origin = window.location.origin;
     const pathname = window.location.pathname;
-    const graphUrl = new URL(sampleQuery.sampleUrl).origin;
+    const url = new URL(sampleUrl);
+    const graphUrl = url.origin;
     /**
      * To ensure backward compatibility the version is removed from the pathname.
      * V3 expects the request query param to not have the version number.
      */
-    const graphUrlRequest = new URL(sampleQuery.sampleUrl).pathname.substr(6);
-    const requestBody = this.hashEncode(JSON.stringify(sampleQuery.sampleBody));
+    const graphUrlRequest = url.pathname.substr(6) + url.search;
+    const requestBody = this.hashEncode(JSON.stringify(sampleBody));
 
     return origin + pathname
       + '?request=' + graphUrlRequest
-      + '&method=' + sampleQuery.selectedVerb
-      + '&version=' + sampleQuery.selectedVersion
+      + '&method=' + selectedVerb
+      + '&version=' + selectedVersion
       + '&GraphUrl=' + graphUrl
       + '&requestBody=' + requestBody;
   }

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -4,7 +4,6 @@ import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
 
-
 import { ThemeContext } from '../../../themes/theme-context';
 import { Mode } from '../../../types/action';
 import { IQueryResponseProps } from '../../../types/query-response';
@@ -55,14 +54,18 @@ class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialo
      * V3 expects the request query param to not have the version number.
      */
     const graphUrlRequest = new URL(sampleQuery.sampleUrl).pathname.substr(6);
-    const uriEncodedRequestBody = encodeURI(JSON.stringify(sampleQuery.sampleBody));
+    const requestBody = this.hashEncode(JSON.stringify(sampleQuery.sampleBody));
 
     return origin + pathname
       + '?request=' + graphUrlRequest
       + '&method=' + sampleQuery.selectedVerb
       + '&version=' + sampleQuery.selectedVersion
       + '&GraphUrl=' + graphUrl
-      + '&requestBody' + uriEncodedRequestBody;
+      + '&requestBody=' + requestBody;
+  }
+
+  private hashEncode(requestBody: string): string {
+    return btoa(requestBody);
   }
 
   public render() {

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,4 +1,4 @@
-import { Pivot, PivotItem } from 'office-ui-fabric-react';
+import { IconButton, Pivot, PivotItem } from 'office-ui-fabric-react';
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
@@ -7,7 +7,7 @@ import { ThemeContext } from '../../../themes/theme-context';
 import { Mode } from '../../../types/action';
 import { IQueryResponseProps } from '../../../types/query-response';
 import { Image, Monaco } from '../common';
-import AdaptiveCard  from './adaptive-cards/AdaptiveCard';
+import AdaptiveCard from './adaptive-cards/AdaptiveCard';
 import { darkThemeHostConfig, lightThemeHostConfig } from './adaptive-cards/AdaptiveHostConfig';
 import './query-response.scss';
 import { Snippets } from './snippets';
@@ -53,8 +53,8 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
             alt='profile image'
           />
         ) : (
-          <Monaco body={body} verb={verb} />
-        )}
+            <Monaco body={body} verb={verb} />
+          )}
       </PivotItem>,
       <PivotItem
         key='response-headers'
@@ -68,7 +68,7 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
     if (mode === Mode.Complete) {
       pivotItems.push(
         <PivotItem
-          key = 'adaptive-cards'
+          key='adaptive-cards'
           ariaLabel='Adaptive Cards'
           headerText={messages['Adaptive Cards']}
         >
@@ -76,7 +76,7 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
             {(theme) => (
               // @ts-ignore
               <AdaptiveCard
-                body= {body}
+                body={body}
                 hostConfig={theme === 'light' ? lightThemeHostConfig : darkThemeHostConfig}
               />
             )}
@@ -89,13 +89,16 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
           ariaLabel='Code Snippets'
           headerText={messages.Snippets}
         >
-          <Snippets/>
+          <Snippets />
         </PivotItem>
       );
     }
 
     return (
-      <div className='query-response'>
+      <div className='query-response' style={{ display: 'block' }}>
+        <IconButton className='share-query-btn' iconProps={{
+          iconName: 'Share'
+        }} />
         <Pivot className='pivot-response'>
           {pivotItems}
         </Pivot>
@@ -106,9 +109,9 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
 
 function mapStateToProps(state: any) {
   return {
-    graphResponse:  state.graphResponse,
+    graphResponse: state.graphResponse,
     appTheme: state.theme,
-    mode : state.graphExplorerMode,
+    mode: state.graphExplorerMode,
     scopes: state.scopes.data,
   };
 }

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -178,8 +178,8 @@ class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialo
             resize: 'none'
           }} className='share-query-params' id='share-query-text' defaultValue={query} />
           <DialogFooter>
-            <PrimaryButton text='Copy' onClick={this.handleCopy} />
-            <DefaultButton text='Close' onClick={this.toggleShareQueryDialogState} />
+            <PrimaryButton text={messages.Copy} onClick={this.handleCopy} />
+            <DefaultButton text={messages.Close} onClick={this.toggleShareQueryDialogState} />
           </DialogFooter>
         </Dialog>
       </div>

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -1,7 +1,9 @@
-import { IconButton, Pivot, PivotItem } from 'office-ui-fabric-react';
+import { DefaultButton, IconButton, Pivot, PivotItem, PrimaryButton, } from 'office-ui-fabric-react';
+import { Dialog, DialogFooter, DialogType } from 'office-ui-fabric-react/lib/Dialog';
 import React, { Component } from 'react';
 import { injectIntl } from 'react-intl';
 import { connect } from 'react-redux';
+
 
 import { ThemeContext } from '../../../themes/theme-context';
 import { Mode } from '../../../types/action';
@@ -12,13 +14,23 @@ import { darkThemeHostConfig, lightThemeHostConfig } from './adaptive-cards/Adap
 import './query-response.scss';
 import { Snippets } from './snippets';
 
-class QueryResponse extends Component<IQueryResponseProps, {}> {
+class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialog: boolean, query: string }> {
   constructor(props: any) {
     super(props);
+    this.state = {
+      showShareQueryDialog: true,
+      query: '',
+    };
   }
 
   public handleShareQuery = () => {
     const query = this.generateShareQueryParams();
+    this.setState({ query });
+    this.toggleShareQueryDialogState();
+  }
+
+  public toggleShareQueryDialogState = () => {
+    this.setState({ showShareQueryDialog: !this.state.showShareQueryDialog });
   }
 
   private generateShareQueryParams = (): string => {
@@ -50,7 +62,9 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
       verb
     }: any = this.props;
 
+    const { showShareQueryDialog, query } = this.state;
     const { graphResponse, mode } = this.props;
+
     if (graphResponse) {
       body = graphResponse.body;
       headers = graphResponse.headers;
@@ -119,13 +133,33 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
     }
 
     return (
-      <div className='query-response'>
-        <IconButton onClick={this.handleShareQuery} className='share-query-btn' iconProps={{
-          iconName: 'Share'
-        }} />
-        <Pivot className='pivot-response'>
-          {pivotItems}
-        </Pivot>
+      <div>
+        <div className='query-response'>
+          <IconButton onClick={this.handleShareQuery} className='share-query-btn' iconProps={{
+            iconName: 'Share'
+          }} />
+          <Pivot className='pivot-response'>
+            {pivotItems}
+          </Pivot>
+        </div>
+        <Dialog
+          hidden={showShareQueryDialog}
+          onDismiss={this.toggleShareQueryDialogState}
+          dialogContentProps={{
+            type: DialogType.normal,
+            title: 'Share Query',
+            isMultiline: true,
+            subText: messages['Share Query Message']
+          }}
+        >
+          <p className='share-query-params'>
+            {query}
+          </p>
+          <DialogFooter>
+            <PrimaryButton text='Copy' />
+            <DefaultButton text='Close' onClick={this.toggleShareQueryDialogState} />
+          </DialogFooter>
+        </Dialog>
       </div>
     );
   }

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -17,6 +17,30 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
     super(props);
   }
 
+  public handleShareQuery = () => {
+    const query = this.generateShareQueryParams();
+  }
+
+  private generateShareQueryParams = (): string => {
+    const { sampleQuery } = this.props;
+    const origin = window.location.origin;
+    const pathname = window.location.pathname;
+    const graphUrl = new URL(sampleQuery.sampleUrl).origin;
+    /**
+     * To ensure backward compatibility the version is removed from the pathname.
+     * V3 expects the request query param to not have the version number.
+     */
+    const graphUrlRequest = new URL(sampleQuery.sampleUrl).pathname.substr(6);
+    const uriEncodedRequestBody = encodeURI(JSON.stringify(sampleQuery.sampleBody));
+
+    return origin + pathname
+      + '?request=' + graphUrlRequest
+      + '&method=' + sampleQuery.selectedVerb
+      + '&version=' + sampleQuery.selectedVersion
+      + '&GraphUrl=' + graphUrl
+      + '&requestBody' + uriEncodedRequestBody;
+  }
+
   public render() {
     let body: any;
     let headers;
@@ -95,8 +119,8 @@ class QueryResponse extends Component<IQueryResponseProps, {}> {
     }
 
     return (
-      <div className='query-response' style={{ display: 'block' }}>
-        <IconButton className='share-query-btn' iconProps={{
+      <div className='query-response'>
+        <IconButton onClick={this.handleShareQuery} className='share-query-btn' iconProps={{
           iconName: 'Share'
         }} />
         <Pivot className='pivot-response'>
@@ -113,6 +137,7 @@ function mapStateToProps(state: any) {
     appTheme: state.theme,
     mode: state.graphExplorerMode,
     scopes: state.scopes.data,
+    sampleQuery: state.sampleQuery
   };
 }
 

--- a/src/app/views/query-response/QueryResponse.tsx
+++ b/src/app/views/query-response/QueryResponse.tsx
@@ -6,14 +6,14 @@ import { connect } from 'react-redux';
 
 import { ThemeContext } from '../../../themes/theme-context';
 import { Mode } from '../../../types/action';
-import { IQueryResponseProps } from '../../../types/query-response';
+import { IQueryResponseProps, IQueryResponseState } from '../../../types/query-response';
 import { Image, Monaco } from '../common';
 import AdaptiveCard from './adaptive-cards/AdaptiveCard';
 import { darkThemeHostConfig, lightThemeHostConfig } from './adaptive-cards/AdaptiveHostConfig';
 import './query-response.scss';
 import { Snippets } from './snippets';
 
-class QueryResponse extends Component<IQueryResponseProps, { showShareQueryDialog: boolean, query: string }> {
+class QueryResponse extends Component<IQueryResponseProps, IQueryResponseState> {
   constructor(props: any) {
     super(props);
     this.state = {

--- a/src/app/views/query-response/query-response.scss
+++ b/src/app/views/query-response/query-response.scss
@@ -26,6 +26,7 @@
   .share-query-btn {
     float: right;
     padding-top: 15px;
+    z-index: 10;
   }
 }
 

--- a/src/app/views/query-response/query-response.scss
+++ b/src/app/views/query-response/query-response.scss
@@ -31,3 +31,11 @@
   }
 }
 
+.share-query-params {
+  font-family: 'monospace';
+  font-size: 12px;
+  width: '100%';
+  overflow-x: auto;
+  overflow-y: hidden;
+}
+

--- a/src/app/views/query-response/query-response.scss
+++ b/src/app/views/query-response/query-response.scss
@@ -7,6 +7,7 @@
   height: 610px;
   border: 1px solid silver;
   overflow: hidden;
+  display: block;
 
 
   .ms-Pivot.root-84 {
@@ -20,6 +21,11 @@
     font-size: 50px;
     justify-content: center;
     align-items: center;
+  }
+
+  .share-query-btn {
+    float: right;
+    padding-top: 15px;
   }
 }
 

--- a/src/app/views/query-response/query-response.scss
+++ b/src/app/views/query-response/query-response.scss
@@ -25,8 +25,9 @@
 
   .share-query-btn {
     float: right;
-    padding-top: 15px;
-    z-index: 10;
+    margin-top: 10px;
+    padding: 0px;
+    z-index: 1;
   }
 }
 

--- a/src/messages/en-US.json
+++ b/src/messages/en-US.json
@@ -261,5 +261,7 @@
   "Sign In to see your access token.": "Sign In to see your access token.",
   "Sign In to try this sample": "Sign In to try this sample",
   "Signing you in...": "Signing you in...",
-  "Share Query Message": "Share this link to let people try your current query in the Graph Explorer"
+  "Share Query Message": "Share this link to let people try your current query in the Graph Explorer",
+  "Copy": "Copy",
+  "Close": "Close"
 }

--- a/src/messages/en-US.json
+++ b/src/messages/en-US.json
@@ -260,5 +260,6 @@
   "Permissions": "Permissions",
   "Sign In to see your access token.": "Sign In to see your access token.",
   "Sign In to try this sample": "Sign In to try this sample",
-  "Signing you in...": "Signing you in..."
+  "Signing you in...": "Signing you in...",
+  "Share Query Message": "Share this link to let people try your current query in the Graph Explorer"
 }

--- a/src/messages/en-US.json
+++ b/src/messages/en-US.json
@@ -262,6 +262,5 @@
   "Sign In to try this sample": "Sign In to try this sample",
   "Signing you in...": "Signing you in...",
   "Share Query Message": "Share this link to let people try your current query in the Graph Explorer",
-  "Copy": "Copy",
-  "Close": "Close"
+  "Copy": "Copy"
 }

--- a/src/types/query-response.ts
+++ b/src/types/query-response.ts
@@ -1,4 +1,5 @@
 import { Mode } from './action';
+import { IQuery } from './query-runner';
 
 export interface IQueryResponseProps {
   mode: Mode;
@@ -13,6 +14,7 @@ export interface IQueryResponseProps {
   verb: string;
   theme: string;
   scopes: string[];
+  sampleQuery: IQuery;
   actions: {
     getConsent: Function;
   };

--- a/src/types/query-response.ts
+++ b/src/types/query-response.ts
@@ -19,3 +19,8 @@ export interface IQueryResponseProps {
     getConsent: Function;
   };
 }
+
+export interface IQueryResponseState {
+  showShareQueryDialog: boolean;
+  query: string;
+}

--- a/src/types/share-query.ts
+++ b/src/types/share-query.ts
@@ -1,0 +1,7 @@
+export interface ISharedQueryParams {
+  request: string | null;
+  method: string | null;
+  version: string | null;
+  requestBody?: string | null;
+  graphUrl: string | null;
+}


### PR DESCRIPTION
## Overview

* Allows users to share queries between Graph Explorer(s)
* Adds support for sharing request bodies(v4 only)
* Adds support for sharing queries between v4 & v3
### Demo

![image](https://user-images.githubusercontent.com/12011447/68936097-dce43700-07aa-11ea-8e2c-1ddbcd88e24d.png)

### Notes

#### Backwards Compatibility
This Query sharing feature is backward compatible with GE v3. Sharing the request body is only available for v4. Adding support for request body in v3 will involve feature work and as it is now v3 is on a feature freeze.

#### Encoding Request Body
The `request body` shared between instances of GE is `Base64` encoded. In principle the `Base64` string should be smaller than the actual contents of the encoded string helping us avoid url character limit.

## Testing Instructions

* Launch Graph Explorer
* Click Share button
* Copy the url in the dialog
* Open the url on web client running v3 or v4
* Observe that the QueryInput is updated

Close #143 