### PR TITLE
Fix: Calendarview query not working

### DIFF
--- a/src/app/services/actions/query-action-creator-util.ts
+++ b/src/app/services/actions/query-action-creator-util.ts
@@ -21,7 +21,8 @@ export function queryResponse(response: object): IAction {
 export async function anonymousRequest(dispatch: Function, query: IQuery) {
 
   const authToken = '{token:https://graph.microsoft.com/}';
-  const graphUrl = `https://proxy.apisandbox.msdn.microsoft.com/svc?url=${query.sampleUrl}`;
+  const escapedUrl = escape(query.sampleUrl);
+  const graphUrl = `https://proxy.apisandbox.msdn.microsoft.com/svc?url=${escapedUrl}`;
   const sampleHeaders: any = {};
 
   if (query.sampleHeaders) {


### PR DESCRIPTION
## Overview

Running [this query](https://graph.microsoft.com/v1.0/me/calendarview?startdatetime=2020-01-27T09:01:07.519Z&enddatetime=2020-02-03T09:01:07.519Z ) in v3 worked but not in v4.

Fixes #349 

### Demo

Optional. Screenshots, `curl` examples, etc.

### Notes

Anonymous requests sent to the proxy services should be escaped so that the API can show the data

## Testing Instructions

* Spin up the app
* Run [this query](https://graph.microsoft.com/v1.0/me/calendarview?startdatetime=2020-01-27T09:01:07.519Z&enddatetime=2020-02-03T09:01:07.519Z ) in an anonymous state
* Notice the presence of results